### PR TITLE
feat(twin): palace_get_twin / palace_put_twin over a dedicated twins table

### DIFF
--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -274,9 +274,11 @@ const TOOL_TO_OP: Record<string, string> = {
   palace_get_room: "recall",
   palace_walk_tunnel: "recall",
   palace_stats: "recall",
+  palace_get_twin: "recall",
 
   // Write ops → remember
   palace_remember: "remember",
+  palace_put_twin: "remember",
   palace_add_closet: "remember",
   palace_add_drawer: "remember",
   palace_create_room: "remember",

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -291,17 +291,21 @@ async function dispatch(
       });
 
     // ── TWIN (per-seat structured state; addressed, never searched) ──
+    // Scope: keyed by (palaceId, AUTHENTICATED neopId) only. `neopId` here is the resolved
+    // caller identity (http handler overwrites any params.neopId before dispatch), and perms
+    // were already gated (get→recall, put→remember). A caller can only reach its OWN twin —
+    // no params override, no cross-seat read/write. Same tenant+seat discipline as palace_search.
     case "palace_get_twin":
       return ctx.runQuery(api.palace.twins.getTwin, {
         palaceId,
-        neopId: (params.neopId as string) ?? neopId,
+        neopId,
       });
 
     case "palace_put_twin":
       // Blind upsert; broker owns versioning (no server-side version check here).
       return ctx.runMutation(api.palace.twins.putTwin, {
         palaceId,
-        neopId: (params.neopId as string) ?? neopId,
+        neopId,
         doc: params.doc as string,
         version: params.version as number,
         maturity: params.maturity as string,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -290,6 +290,23 @@ async function dispatch(
         relationshipFilter: params.relationshipFilter as string | undefined,
       });
 
+    // ── TWIN (per-seat structured state; addressed, never searched) ──
+    case "palace_get_twin":
+      return ctx.runQuery(api.palace.twins.getTwin, {
+        palaceId,
+        neopId: (params.neopId as string) ?? neopId,
+      });
+
+    case "palace_put_twin":
+      // Blind upsert; broker owns versioning (no server-side version check here).
+      return ctx.runMutation(api.palace.twins.putTwin, {
+        palaceId,
+        neopId: (params.neopId as string) ?? neopId,
+        doc: params.doc as string,
+        version: params.version as number,
+        maturity: params.maturity as string,
+      });
+
     // ── STORAGE ───────────────────────────────────────────
     case "palace_remember":
       return ctx.runAction(api.ingestion.ingest.ingestExchange, {

--- a/convex/palace/twins.ts
+++ b/convex/palace/twins.ts
@@ -1,0 +1,65 @@
+// Twin accessors — per-seat structured state, ADDRESSED by (palaceId, neopId).
+//
+// A twin is NOT a closet: it is never embedded, never vector-indexed, and never returned by
+// palace_search. It is read/written by address. The NEOS broker (MemoryBroker.put_twin) is the
+// SOLE owner of versioning + stale-base rejection (see MEMPALACE_TWIN_CONTRACT.md); putTwin here
+// is a blind "latest wins" upsert with NO server-side version check — one owner, no double-gate.
+// Correct under single-writer-per-twin (the Twin Curator). If concurrent twin writers are ever
+// introduced, move the gate server-side (write iff stored version == base) — do not split it.
+
+import { query, mutation } from "../_generated/server.js";
+import { v } from "convex/values";
+
+// palace_get_twin → { twin: <object> | null, version?, maturity?, updatedAt? }
+export const getTwin = query({
+  args: { palaceId: v.id("palaces"), neopId: v.string() },
+  handler: async (ctx, { palaceId, neopId }) => {
+    const row = await ctx.db
+      .query("twins")
+      .withIndex("by_palace_neop", (q) =>
+        q.eq("palaceId", palaceId).eq("neopId", neopId),
+      )
+      .first();
+    if (!row) return { twin: null };
+    return {
+      twin: JSON.parse(row.doc),
+      version: row.version,
+      maturity: row.maturity,
+      updatedAt: row.updatedAt,
+    };
+  },
+});
+
+// palace_put_twin → { status, twinId, version, upsert }. Blind upsert by (palaceId, neopId):
+// latest wins, NO version check (the broker already enforced stale-base before calling).
+export const putTwin = mutation({
+  args: {
+    palaceId: v.id("palaces"),
+    neopId: v.string(),
+    doc: v.string(),
+    version: v.number(),
+    maturity: v.string(),
+  },
+  handler: async (ctx, { palaceId, neopId, doc, version, maturity }) => {
+    const existing = await ctx.db
+      .query("twins")
+      .withIndex("by_palace_neop", (q) =>
+        q.eq("palaceId", palaceId).eq("neopId", neopId),
+      )
+      .first();
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, { doc, version, maturity, updatedAt: now });
+      return { status: "ok", twinId: existing._id, version, upsert: "update" };
+    }
+    const id = await ctx.db.insert("twins", {
+      palaceId,
+      neopId,
+      doc,
+      version,
+      maturity,
+      updatedAt: now,
+    });
+    return { status: "ok", twinId: id, version, upsert: "insert" };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -304,6 +304,26 @@ export default defineSchema({
     .index("by_palace_from", ["palaceId", "fromRoomId"])
     .index("by_palace_to", ["palaceId", "toRoomId"]),
 
+  // ── TWINS (per-seat structured state — ADDRESSED, never searched) ──
+  //
+  // A twin is one structured record per (palaceId, neopId). Unlike closets it is NOT embedded,
+  // NOT vector-indexed, and never surfaces in palace_search — it is fetched/written by address.
+  // `doc` is the serialized twin JSON; the NEOS broker (MemoryBroker.put_twin) is the SOLE owner
+  // of versioning + stale-base rejection (see MEMPALACE_TWIN_CONTRACT.md). putTwin here is a
+  // blind "latest wins" upsert with NO server-side version check — single owner, no double-gate.
+  // Safe under single-writer-per-twin (Twin Curator); concurrent writers would need a server-side
+  // conditional upsert (write iff stored version == base). version/maturity are denormalized for
+  // cheap reads/debugging only; `doc` is the source of truth.
+  twins: defineTable({
+    palaceId: v.id("palaces"),
+    neopId: v.string(),                    // = seat (the routed NEop)
+    doc: v.string(),                       // serialized twin JSON (broker owns the schema)
+    version: v.number(),                   // denormalized; broker is source of truth
+    maturity: v.string(),                  // denormalized: seed|growing|mature|drifted
+    updatedAt: v.number(),
+  })
+    .index("by_palace_neop", ["palaceId", "neopId"]),
+
   // ── VECTOR EMBEDDINGS (versioned by model) ───────────────────
 
   closet_embeddings: defineTable({


### PR DESCRIPTION
## What
Adds two MCP tools so the NEOS runtime can persist and read per-seat **twins** (the twin layer's structured state): `palace_get_twin` / `palace_put_twin`, backed by a new `twins` table.

## Why a new table (not a closet)
The NEOS-side contract originally specced storing the twin "as a closet." Reading this schema corrected that: `closets` are **embedded, vector-indexed, append-only, searchable** memory units in the room→wing hierarchy — exactly what a twin must *not* be (a twin must never surface in `palace_search`). So this uses a dedicated `twins` table, **addressed** by `(palaceId, neopId)`, never embedded.

## Changes
- `convex/schema.ts` — `twins` table `{palaceId, neopId, doc, version, maturity, updatedAt}`, index `by_palace_neop`. `doc` = serialized twin JSON (the NEOS broker owns the twin schema).
- `convex/palace/twins.ts` — `getTwin` query, `putTwin` mutation.
- `convex/http.ts` — `palace_get_twin` / `palace_put_twin` dispatch cases.
- `convex/access/enforce.ts` — `palace_get_twin → recall`, `palace_put_twin → remember`.

## Version ownership (deliberate)
`putTwin` is a **blind upsert by `(palaceId, neopId)` — latest wins, NO server-side version check.** The NEOS broker (`MemoryBroker.put_twin`) is the **sole** owner of versioning + stale-base rejection. This avoids a double-gate. It is correct under **single-writer-per-twin** (the Twin Curator). If concurrent twin writers are ever introduced, move the gate server-side (write iff stored version == base) — do not split it. (Full rationale in the NEOS-side `MEMPALACE_TWIN_CONTRACT.md`.)

## Notes
- A twin is never embedded and excluded from `palace_search` by construction (separate table).
- Authored against the NEOS client in `mansi118/NEURAL-ops` (`runtime/memory.py` → `palace_get_twin {}` / `palace_put_twin {doc, version, maturity}`; client unwraps the `{status, data}` envelope).
- ⚠️ Not compiled locally (no node_modules in the authoring env). CI `npm ci` + vitest + `convex` codegen on deploy are the validation gate — please confirm green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)