### PR TITLE
feat(acl): Phase-1 seat isolation — Gates A + B + B-2 (Convex SoT + /mcp dispatch) + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+# Runs the Convex test suite — including the seat-isolation ACL (Layers 1 + 3 + B-2):
+#   - tests/access.test.ts : pure scope predicates + 13 end-to-end /mcp dispatch tests
+#     (convex-test t.fetch) — cross-seat/company writes & cross-seat reads return 403,
+#     list-filter drops foreign rooms, one-hop closet/drawer resolution, admin bypass.
+#   - tests/palace.test.ts : Phase-1 invariants + Gate B-2 owner-namespaced room routing.
+# vitest does not typecheck (that's the separate `typecheck` script), and convex-test
+# resolves functions dynamically, so the suite runs against the committed _generated.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm ci
+      - name: vitest (ACL Layers 1+3 + Gate B-2)
+        run: npm test

--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -297,3 +297,79 @@ const TOOL_TO_OP: Record<string, string> = {
 export function runtimeOpForTool(tool: string): string | null {
   return TOOL_TO_OP[tool] ?? null;
 }
+
+// ─── Seat isolation: per-room ownership (Phase 1 ACL) ────────────
+//
+// A room carries an optional `ownerNeopId`:
+//   - set   → PERSONAL room, owned by that seat (neopId).
+//   - unset → shared COMPANY room (all legacy rooms + admin-created).
+//
+// read-scope ⊇ write-scope (S3 §3.2.1), two SEPARATE predicates:
+//   • assertNeopScope     (WRITE) — a scoped seat may write ONLY its own room.
+//   • assertNeopReadScope (READ)  — a scoped seat may read its own room OR any
+//                                   company room; a room owned by ANOTHER seat is denied.
+//
+// IDENTITY POSTURE (Phase 1, honest-caller): neopId is the caller's DECLARED seat —
+// there is no signed per-seat credential yet (http.ts resolves `body.neopId ?? header
+// ?? _admin`). This is adequate for cooperating seats inside ONE tenant (the V2-alpha
+// threat model: prevent accidental cross-seat contamination, NOT defend against a
+// forged neopId). Cryptographic per-seat identity (signed X-NEop-Identity) is DEFERRED
+// to the multi-tenant / adversarial phase. Do not present Phase 1 isolation as
+// defense against a malicious seat that lies about its neopId.
+
+/** Minimal shape needed to decide room scope — just the ownership field. */
+export interface RoomScope {
+  ownerNeopId?: string | null;
+}
+
+/** True iff this seat owns the room (a personal room keyed to it). */
+export function ownsRoom(perms: ResolvedPermissions, room: RoomScope): boolean {
+  return !!room.ownerNeopId && room.ownerNeopId === perms.effectiveNeopId;
+}
+
+/** True iff the room is a shared company room (no owner). */
+export function isCompanyRoom(room: RoomScope): boolean {
+  return room.ownerNeopId === undefined || room.ownerNeopId === null;
+}
+
+/** READ scope: own room OR any company room. Another seat's room → false. */
+export function canReadRoom(perms: ResolvedPermissions, room: RoomScope): boolean {
+  if (perms.isAdmin) return true;
+  return ownsRoom(perms, room) || isCompanyRoom(room);
+}
+
+/** WRITE scope: own room ONLY. Company rooms are read-only for a scoped seat. */
+export function canWriteRoom(perms: ResolvedPermissions, room: RoomScope): boolean {
+  if (perms.isAdmin) return true;
+  return ownsRoom(perms, room);
+}
+
+/** Throwing WRITE guard — a scoped seat may write only its own room. */
+export function assertNeopScope(perms: ResolvedPermissions, room: RoomScope): void {
+  if (!canWriteRoom(perms, room)) {
+    const owner = room.ownerNeopId ?? "(company)";
+    throw new AccessDenied(
+      perms.neopId,
+      `cannot write to room owned by "${owner}" — writes are restricted to this seat's own room`,
+    );
+  }
+}
+
+/** Throwing READ guard — a scoped seat may read its own room or a company room. */
+export function assertNeopReadScope(perms: ResolvedPermissions, room: RoomScope): void {
+  if (!canReadRoom(perms, room)) {
+    throw new AccessDenied(
+      perms.neopId,
+      `cannot read room owned by "${room.ownerNeopId}" — not this seat's room`,
+    );
+  }
+}
+
+/** Drop rooms this seat may not read (own + company kept; other seats' dropped). */
+export function filterRoomsByReadScope<T extends RoomScope>(
+  perms: ResolvedPermissions,
+  rooms: T[],
+): T[] {
+  if (perms.isAdmin) return rooms;
+  return rooms.filter((r) => canReadRoom(perms, r));
+}

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -24,6 +24,10 @@ import {
   applyScopeToFilter,
   filterByReadAccess,
   runtimeOpForTool,
+  // Seat isolation (Phase 1 ACL, Gate B): per-room ownership guards.
+  assertNeopScope,
+  assertNeopReadScope,
+  filterRoomsByReadScope,
   AccessDenied,
 } from "./access/enforce.js";
 
@@ -153,6 +157,38 @@ http.route({
   }),
 });
 
+// ─── Seat-isolation helpers (Gate B) ────────────────────────────
+// Resolve the owning room for an addressed entity, then the caller applies the
+// pure scope guard (assertNeopScope / assertNeopReadScope). Used by non-admin
+// callers only — admin short-circuits before any of these fetch.
+
+async function loadRoom(
+  ctx: any,
+  roomId: Id<"rooms">,
+): Promise<{ ownerNeopId?: string | null; wingId: Id<"wings"> }> {
+  const room = await ctx.runQuery(api.palace.queries.getRoom, { roomId });
+  if (!room) throw new Error(`room ${roomId} not found`);
+  return room;
+}
+
+async function roomOfCloset(
+  ctx: any,
+  closetId: Id<"closets">,
+): Promise<{ ownerNeopId?: string | null }> {
+  const closet = await ctx.runQuery(api.palace.queries.getCloset, { closetId });
+  if (!closet) throw new Error(`closet ${closetId} not found`);
+  return loadRoom(ctx, closet.roomId);
+}
+
+async function roomOfDrawer(
+  ctx: any,
+  drawerId: Id<"drawers">,
+): Promise<{ ownerNeopId?: string | null }> {
+  const drawer = await ctx.runQuery(api.palace.queries.getDrawer, { drawerId });
+  if (!drawer) throw new Error(`drawer ${drawerId} not found`);
+  return loadRoom(ctx, drawer.roomId);
+}
+
 // ─── Tool dispatcher (with permissions threaded through) ────────
 
 async function dispatch(
@@ -253,18 +289,24 @@ async function dispatch(
         includeArchived: params.includeArchived as boolean | undefined,
       });
 
-    case "palace_list_rooms":
-      return ctx.runQuery(api.palace.queries.listRoomsByWing, {
+    case "palace_list_rooms": {
+      const rooms: any[] = await ctx.runQuery(api.palace.queries.listRoomsByWing, {
         wingId: params.wingId as Id<"wings">,
       });
+      // Seat isolation: keep own + company rooms; drop other seats' personal rooms.
+      return filterRoomsByReadScope(perms, rooms);
+    }
 
     case "palace_get_room": {
-      // Scope check: can this NEop access this room's wing?
-      if (perms.scopeWing) {
+      if (!perms.isAdmin) {
         const room: any = await ctx.runQuery(api.palace.queries.getRoom, {
           roomId: params.roomId as Id<"rooms">,
         });
-        if (room) {
+        if (!room) throw new Error(`room ${params.roomId} not found`);
+        // Seat isolation: own room OR any company room; another seat's room → deny.
+        assertNeopReadScope(perms, room);
+        // Legacy wing-scope binding (Phase 7) preserved.
+        if (perms.scopeWing) {
           const wing: any = await ctx.runQuery(api.palace.queries.getWingByName, {
             palaceId,
             name: perms.scopeWing,
@@ -282,13 +324,20 @@ async function dispatch(
       });
     }
 
-    case "palace_walk_tunnel":
+    case "palace_walk_tunnel": {
+      // Seat isolation: read-guard the traversal ENTRY room. NOTE (Phase 1):
+      // rooms reached downstream by the walk are not yet per-result filtered
+      // (honest-caller, single-tenant scope). Deep traversal filtering is a follow-up.
+      if (!perms.isAdmin) {
+        assertNeopReadScope(perms, await loadRoom(ctx, params.fromRoomId as Id<"rooms">));
+      }
       return ctx.runQuery(api.serving.tunnels.walkTunnel, {
         palaceId,
         fromRoomId: params.fromRoomId as Id<"rooms">,
         maxDepth: params.maxDepth as number | undefined,
         relationshipFilter: params.relationshipFilter as string | undefined,
       });
+    }
 
     // ── TWIN (per-seat structured state; addressed, never searched) ──
     // Scope: keyed by (palaceId, AUTHENTICATED neopId) only. `neopId` here is the resolved
@@ -312,6 +361,12 @@ async function dispatch(
       });
 
     // ── STORAGE ───────────────────────────────────────────
+    // NOTE (Gate B-2, deferred): palace_remember routes through the TRUSTED
+    // ingestion pipeline (ingestExchange → getOrCreateRoom → createCloset), which
+    // bypasses the per-room write guards below by design. getOrCreateRoom resolves an
+    // existing room by (palaceId, name) IGNORING ownerNeopId, so seat-isolating
+    // remember requires owner-namespaced room resolution — a lookup-semantics fork
+    // tracked separately. Until then, remember is NOT seat-scoped.
     case "palace_remember":
       return ctx.runAction(api.ingestion.ingest.ingestExchange, {
         palaceId,
@@ -330,6 +385,8 @@ async function dispatch(
           roomId: params.roomId as Id<"rooms">,
         });
         if (!room) throw new Error(`room ${params.roomId} not found`);
+        // Seat isolation: a scoped seat may write ONLY its own room.
+        assertNeopScope(perms, room);
         const wings: any[] = await ctx.runQuery(api.palace.queries.listWings, { palaceId });
         const wing = wings.find((w: any) => w._id === room.wingId);
         if (!wing) throw new Error(`wing for room ${params.roomId} not found`);
@@ -353,7 +410,11 @@ async function dispatch(
       });
     }
 
-    case "palace_add_drawer":
+    case "palace_add_drawer": {
+      // Seat isolation: write-guard via the drawer's owning closet → room.
+      if (!perms.isAdmin) {
+        assertNeopScope(perms, await roomOfCloset(ctx, params.closetId as Id<"closets">));
+      }
       return ctx.runMutation(api.palace.mutations.createDrawer, {
         closetId: params.closetId as Id<"closets">,
         palaceId,
@@ -361,6 +422,7 @@ async function dispatch(
         validFrom: Date.now(),
         confidence: (params.confidence as number) ?? 0.8,
       });
+    }
 
     case "palace_create_room":
       // Seat-isolation: a scoped seat's new room is PERSONAL to it; admin creates
@@ -373,7 +435,12 @@ async function dispatch(
         ownerNeopId: perms.isAdmin ? undefined : perms.effectiveNeopId,
       });
 
-    case "palace_create_tunnel":
+    case "palace_create_tunnel": {
+      // Seat isolation: must OWN the origin room (write) and READ the target room.
+      if (!perms.isAdmin) {
+        assertNeopScope(perms, await loadRoom(ctx, params.fromRoomId as Id<"rooms">));
+        assertNeopReadScope(perms, await loadRoom(ctx, params.toRoomId as Id<"rooms">));
+      }
       return ctx.runMutation(api.palace.mutations.createTunnel, {
         palaceId,
         fromRoomId: params.fromRoomId as Id<"rooms">,
@@ -382,27 +449,44 @@ async function dispatch(
         strength: (params.strength as number) ?? 0.5,
         label: params.label as string | undefined,
       });
+    }
 
     // ── MAINTENANCE ───────────────────────────────────────
-    case "palace_invalidate":
+    case "palace_invalidate": {
+      // Seat isolation: write-guard via the drawer's owning room.
+      if (!perms.isAdmin) {
+        assertNeopScope(perms, await roomOfDrawer(ctx, params.drawerId as Id<"drawers">));
+      }
       return ctx.runMutation(api.palace.mutations.invalidateDrawer, {
         drawerId: params.drawerId as Id<"drawers">,
         supersededBy: params.supersededBy as Id<"drawers"> | undefined,
       });
+    }
 
-    case "palace_retract_closet":
+    case "palace_retract_closet": {
+      // Seat isolation: write-guard via the closet's owning room.
+      if (!perms.isAdmin) {
+        assertNeopScope(perms, await roomOfCloset(ctx, params.closetId as Id<"closets">));
+      }
       return ctx.runMutation(api.palace.mutations.retractCloset, {
         closetId: params.closetId as Id<"closets">,
         reason: params.reason as string,
         retractedBy: neopId,
       });
+    }
 
-    case "palace_merge_rooms":
+    case "palace_merge_rooms": {
+      // Seat isolation: destructive cross-room write — must OWN both source and target.
+      if (!perms.isAdmin) {
+        assertNeopScope(perms, await loadRoom(ctx, params.sourceRoomId as Id<"rooms">));
+        assertNeopScope(perms, await loadRoom(ctx, params.targetRoomId as Id<"rooms">));
+      }
       return ctx.runMutation(api.palace.mutations.mergeRooms, {
         palaceId,
         sourceRoomId: params.sourceRoomId as Id<"rooms">,
         targetRoomId: params.targetRoomId as Id<"rooms">,
       });
+    }
 
     // ── META ──────────────────────────────────────────────
     case "palace_stats":

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -363,11 +363,14 @@ async function dispatch(
       });
 
     case "palace_create_room":
+      // Seat-isolation: a scoped seat's new room is PERSONAL to it; admin creates
+      // shared/company rooms (no owner). Honest-caller neopId (Phase 1 posture).
       return ctx.runMutation(api.palace.mutations.getOrCreateRoom, {
         palaceId,
         wingName: params.wingName as string,
         roomName: params.roomName as string,
         summary: params.summary as string | undefined,
+        ownerNeopId: perms.isAdmin ? undefined : perms.effectiveNeopId,
       });
 
     case "palace_create_tunnel":

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -361,12 +361,12 @@ async function dispatch(
       });
 
     // ── STORAGE ───────────────────────────────────────────
-    // NOTE (Gate B-2, deferred): palace_remember routes through the TRUSTED
-    // ingestion pipeline (ingestExchange → getOrCreateRoom → createCloset), which
-    // bypasses the per-room write guards below by design. getOrCreateRoom resolves an
-    // existing room by (palaceId, name) IGNORING ownerNeopId, so seat-isolating
-    // remember requires owner-namespaced room resolution — a lookup-semantics fork
-    // tracked separately. Until then, remember is NOT seat-scoped.
+    // palace_remember routes through the TRUSTED ingestion pipeline (ingestExchange →
+    // getOrCreateRoom → createCloset), which bypasses the per-room write guards by design.
+    // Seat isolation is achieved at the ROUTING layer instead (Gate B-2): the caller's seat
+    // is passed as ownerNeopId, so getOrCreateRoom resolves/creates rooms in this seat's OWN
+    // owner-namespace — auto-routed memory can never land in a company- or another-seat's room.
+    // Admin remembers into shared company rooms (ownerNeopId=undefined).
     case "palace_remember":
       return ctx.runAction(api.ingestion.ingest.ingestExchange, {
         palaceId,
@@ -376,6 +376,7 @@ async function dispatch(
         conversationId: `mcp_${neopId}_${Date.now()}`,
         conversationTitle: (params.title as string) ?? "MCP memory",
         exchangeIndex: 0,
+        ownerNeopId: perms.isAdmin ? undefined : perms.effectiveNeopId,
       });
 
     case "palace_add_closet": {

--- a/convex/ingestion/ingest.ts
+++ b/convex/ingestion/ingest.ts
@@ -56,6 +56,10 @@ export const ingestExchange = action({
     conversationId: v.string(),
     conversationTitle: v.string(),
     exchangeIndex: v.number(),
+    // Seat-isolation (Gate B-2): when set, auto-routed rooms resolve/create in this seat's
+    // OWN namespace so remembered memory is private to it. Unset = shared COMPANY rooms
+    // (bulk archive/admin ingestion, unchanged).
+    ownerNeopId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<IngestResult> => {
     const t0 = Date.now();
@@ -126,6 +130,7 @@ export const ingestExchange = action({
             wingName: item.wing,
             roomName: item.room,
             summary: item.title,
+            ownerNeopId: args.ownerNeopId,   // seat-isolation: route to the caller's namespace
           },
         );
 

--- a/convex/palace/mutations.ts
+++ b/convex/palace/mutations.ts
@@ -206,10 +206,12 @@ export const createRoom = mutation({
       throw new Error("wing.palaceId mismatch with provided palaceId");
     }
 
+    // Owner-namespaced dedup (Gate B-2): resolve within the caller's owner namespace so a
+    // seat's room of a given name is distinct from the company room of the same name.
     const existing = await ctx.db
       .query("rooms")
-      .withIndex("by_palace_name", (q) =>
-        q.eq("palaceId", args.palaceId).eq("name", args.name),
+      .withIndex("by_palace_owner_name", (q) =>
+        q.eq("palaceId", args.palaceId).eq("ownerNeopId", args.ownerNeopId).eq("name", args.name),
       )
       .first();
     if (existing) return existing._id;
@@ -252,11 +254,14 @@ export const getOrCreateRoom = mutation({
     const wn = args.wingName.toLowerCase().replace(/\s+/g, "-");
     const rn = args.roomName.toLowerCase().replace(/\s+/g, "-");
 
-    // 1. Check if room already exists by name in this palace.
+    // 1. Resolve within the caller's OWNER namespace (Gate B-2): a scoped seat's remember
+    //    lands in/creates ITS OWN room of this name; admin/scripts (ownerNeopId=undefined)
+    //    resolve the shared COMPANY namespace, exactly as before. This is what keeps a
+    //    seat's auto-routed memory from colliding into a company- or another-seat's room.
     const existing = await ctx.db
       .query("rooms")
-      .withIndex("by_palace_name", (q) =>
-        q.eq("palaceId", args.palaceId).eq("name", rn),
+      .withIndex("by_palace_owner_name", (q) =>
+        q.eq("palaceId", args.palaceId).eq("ownerNeopId", args.ownerNeopId).eq("name", rn),
       )
       .first();
     if (existing) return existing._id;

--- a/convex/palace/mutations.ts
+++ b/convex/palace/mutations.ts
@@ -192,6 +192,7 @@ export const createRoom = mutation({
     name: v.string(),
     summary: v.string(),
     tags: v.array(v.string()),
+    ownerNeopId: v.optional(v.string()),   // seat-isolation: set = personal room; unset = company
   },
   handler: async (ctx, args): Promise<Id<"rooms">> => {
     validateSlug(args.name, "room.name");
@@ -222,6 +223,7 @@ export const createRoom = mutation({
       closetCount: 0,
       lastUpdated: Date.now(),
       tags: args.tags,
+      ...(args.ownerNeopId ? { ownerNeopId: args.ownerNeopId } : {}),
     });
 
     // Counter denormalization (atomic with insert via Convex OCC).
@@ -243,6 +245,7 @@ export const getOrCreateRoom = mutation({
     wingName: v.string(),
     roomName: v.string(),
     summary: v.optional(v.string()),
+    ownerNeopId: v.optional(v.string()),   // seat-isolation: stamp personal ownership on create
   },
   handler: async (ctx, args): Promise<Id<"rooms">> => {
     // Normalize names.
@@ -293,6 +296,7 @@ export const getOrCreateRoom = mutation({
         closetCount: 0,
         lastUpdated: Date.now(),
         tags: ["auto-created"],
+        ...(args.ownerNeopId ? { ownerNeopId: args.ownerNeopId } : {}),
       });
       await safePatchHall(ctx, hall._id, { roomCount: hall.roomCount + 1 });
       await safePatchWing(ctx, quarantine._id, {
@@ -321,6 +325,7 @@ export const getOrCreateRoom = mutation({
       closetCount: 0,
       lastUpdated: Date.now(),
       tags: ["auto-created"],
+      ...(args.ownerNeopId ? { ownerNeopId: args.ownerNeopId } : {}),
     });
     await safePatchHall(ctx, hall._id, { roomCount: hall.roomCount + 1 });
     await safePatchWing(ctx, wing._id, {

--- a/convex/palace/queries.ts
+++ b/convex/palace/queries.ts
@@ -210,6 +210,13 @@ export const listClosetsByCategory = query({
 
 // ─── DRAWERS ─────────────────────────────────────────────────
 
+export const getDrawer = query({
+  args: { drawerId: v.id("drawers") },
+  handler: async (ctx, { drawerId }) => {
+    return await ctx.db.get(drawerId);
+  },
+});
+
 export const listDrawers = query({
   args: {
     closetId: v.id("closets"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -202,6 +202,10 @@ export default defineSchema({
     .index("by_palace_name", ["palaceId", "name"])
     .index("by_wing_name", ["wingId", "name"])
     .index("by_palace_owner", ["palaceId", "ownerNeopId"])
+    // Owner-namespaced room resolution (Gate B-2): the same display name can exist once
+    // per owner — a seat's "stack" is distinct from the company "stack" and from another
+    // seat's "stack". ownerNeopId=undefined keys the shared COMPANY namespace (legacy rooms).
+    .index("by_palace_owner_name", ["palaceId", "ownerNeopId", "name"])
     .searchIndex("search_rooms", {
       searchField: "name",
       filterFields: ["palaceId", "wingId"],

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -191,12 +191,17 @@ export default defineSchema({
     closetCount: v.number(),               // denormalized
     lastUpdated: v.number(),
     tags: v.array(v.string()),
+    // Seat-isolation (Phase 1 ACL). Set = PERSONAL room owned by that seat (neopId);
+    // unset/undefined = shared COMPANY room (all legacy rooms + admin-created). Additive,
+    // non-breaking: existing rows read back as company rooms. Write-scope keys on this.
+    ownerNeopId: v.optional(v.string()),
   })
     .index("by_hall", ["hallId"])
     .index("by_wing", ["wingId"])
     .index("by_palace", ["palaceId"])
     .index("by_palace_name", ["palaceId", "name"])
     .index("by_wing_name", ["wingId", "name"])
+    .index("by_palace_owner", ["palaceId", "ownerNeopId"])
     .searchIndex("search_rooms", {
       searchField: "name",
       filterFields: ["palaceId", "wingId"],

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -520,3 +520,24 @@ describe("Gate B — seat isolation through /mcp dispatch", () => {
     expect(status).toBe(200);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// Gate D — Layer 2 (FalkorDB/Graphiti) seat isolation. DEFERRED by decision
+// 2026-06-11: the graph stays tenant-shared (one graph per palace) because
+// seat-isolating it would fragment cross-seat entity resolution. This SKIPPED
+// placeholder keeps the gap VISIBLE (vs silently absent) and pins the exact
+// condition to assert if/when the shared-graph posture is revisited: private-wing
+// content must not produce any cross-seat-traversable edge in the palace graph.
+// The real assertion lives against the bridge (services/graphiti_bridge.py) and
+// is gated on the live FalkorDB backend, so it is not part of the offline suite.
+// ─────────────────────────────────────────────────────────────────
+
+describe("Gate D — graph seat isolation (DEFERRED)", () => {
+  test.skip("acl_graph_no_private_crossseat_edges", () => {
+    // WHEN un-skipped (post-decision to seat-isolate the graph):
+    //   - seat_a writes private-wing content → bridge ingests episode into the palace graph
+    //   - assert NO edge/path makes that content traversable from seat_b's subgraph
+    //     (group_id / namespace boundary holds), while company content stays shared.
+    // Requires a live/stubbed FalkorDB; tracked with Gate D, not offline-gradeable here.
+  });
+});

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -17,6 +17,13 @@ import {
   filterByReadAccess,
   runtimeOpForTool,
   AccessDenied,
+  ownsRoom,
+  isCompanyRoom,
+  canReadRoom,
+  canWriteRoom,
+  assertNeopScope,
+  assertNeopReadScope,
+  filterRoomsByReadScope,
 } from "../convex/access/enforce.js";
 import { ADMIN_NEOP_ID } from "../convex/lib/enums.js";
 
@@ -251,6 +258,66 @@ describe("Search result filtering", () => {
     // clients/conversation ✓ (read: *), legal ✗, team ✗, rd ✗
     expect(filtered.length).toBe(2);
     expect(filtered.map((r) => r.wingName)).toEqual(["platform", "clients"]);
+  });
+});
+
+// ─── Seat isolation: per-room ownership (Phase 1 ACL) ───────────
+
+describe("Seat isolation — room ownership", () => {
+  const ariaRoom = { ownerNeopId: "aria" };       // owned by seat aria
+  const icdRoom = { ownerNeopId: "icd" };          // owned by another seat (icd)
+  const companyRoom = { ownerNeopId: undefined };  // shared/legacy room, no owner
+
+  test("ownsRoom / isCompanyRoom basics", () => {
+    expect(ownsRoom(ARIA, ariaRoom)).toBe(true);
+    expect(ownsRoom(ARIA, icdRoom)).toBe(false);
+    expect(ownsRoom(ARIA, companyRoom)).toBe(false);   // a company room is owned by no seat
+    expect(isCompanyRoom(companyRoom)).toBe(true);
+    expect(isCompanyRoom(ariaRoom)).toBe(false);
+  });
+
+  test("WRITE scope: a scoped seat writes ONLY its own room", () => {
+    expect(canWriteRoom(ARIA, ariaRoom)).toBe(true);
+    expect(canWriteRoom(ARIA, icdRoom)).toBe(false);      // another seat's room — denied
+    expect(canWriteRoom(ARIA, companyRoom)).toBe(false);  // company room is read-only for a seat
+  });
+
+  test("READ scope: own room OR company room; another seat's room denied", () => {
+    expect(canReadRoom(ARIA, ariaRoom)).toBe(true);
+    expect(canReadRoom(ARIA, companyRoom)).toBe(true);    // read ⊇ write — company readable
+    expect(canReadRoom(ARIA, icdRoom)).toBe(false);       // cross-seat read denied
+  });
+
+  test("assertNeopScope (write) throws on cross-seat + company, allows own", () => {
+    expect(() => assertNeopScope(ARIA, icdRoom)).toThrow(AccessDenied);
+    expect(() => assertNeopScope(ARIA, companyRoom)).toThrow(AccessDenied);
+    expect(() => assertNeopScope(ARIA, ariaRoom)).not.toThrow();
+  });
+
+  test("assertNeopReadScope (read) throws only on another seat's room", () => {
+    expect(() => assertNeopReadScope(ARIA, icdRoom)).toThrow(AccessDenied);
+    expect(() => assertNeopReadScope(ARIA, companyRoom)).not.toThrow();
+    expect(() => assertNeopReadScope(ARIA, ariaRoom)).not.toThrow();
+  });
+
+  test("admin bypasses room scope entirely", () => {
+    expect(canWriteRoom(ADMIN, icdRoom)).toBe(true);
+    expect(canReadRoom(ADMIN, icdRoom)).toBe(true);
+    expect(() => assertNeopScope(ADMIN, icdRoom)).not.toThrow();
+  });
+
+  test("scope keys on effectiveNeopId (parent), not the instance neopId", () => {
+    // ICD_ZOO.neopId = "icd_zoo_media" but effectiveNeopId = "icd" (scoped instance).
+    // Ownership must resolve to the PARENT seat, so icd-owned rooms are writable.
+    expect(canWriteRoom(ICD_ZOO, icdRoom)).toBe(true);
+    expect(canWriteRoom(ICD_ZOO, ariaRoom)).toBe(false);
+  });
+
+  test("filterRoomsByReadScope keeps own + company, drops other seats'", () => {
+    const rooms = [ariaRoom, icdRoom, companyRoom];
+    const visible = filterRoomsByReadScope(ARIA, rooms);
+    expect(visible).toEqual([ariaRoom, companyRoom]);
+    expect(filterRoomsByReadScope(ADMIN, rooms)).toEqual(rooms);  // admin sees all
   });
 });
 

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -26,6 +26,9 @@ import {
   filterRoomsByReadScope,
 } from "../convex/access/enforce.js";
 import { ADMIN_NEOP_ID } from "../convex/lib/enums.js";
+import { convexTest } from "convex-test";
+import schema from "../convex/schema.js";
+import { api } from "../convex/_generated/api.js";
 
 // ─── Test permission sets ───────────────────────────────────────
 
@@ -342,5 +345,178 @@ describe("Tool to runtime op mapping", () => {
 
   test("unknown tool returns null", () => {
     expect(runtimeOpForTool("nonexistent_tool")).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Gate B: end-to-end seat isolation through the /mcp HTTP dispatch.
+//
+// Drives the REAL convex/http.ts dispatcher via convex-test's t.fetch — this
+// proves the WIRING (which guard at which case), not just the pure predicates
+// covered above. Every Gate B tool resolves to a Convex query/mutation (no
+// actions ⇒ no network I/O), so both allow AND deny paths grade fully offline.
+// ─────────────────────────────────────────────────────────────────
+
+// Two seats + a company room, all in one "platform" wing. seat_a gets broad
+// content access + all runtime ops, so the ONLY thing that can deny is the new
+// per-room ownership guard — isolating Gate B from the Phase-7 content layer.
+async function setupSeatPalace() {
+  const t = convexTest(schema);
+  const palaceId = await t.mutation(api.palace.mutations.createPalace, {
+    name: "ACL Palace", clientId: "acl", falkordbGraph: "acl_graph", createdBy: "system",
+  });
+  const wingId = await t.mutation(api.palace.mutations.createWing, {
+    palaceId, name: "platform", description: "Platform", sortOrder: 1,
+  });
+  const hallId = await t.mutation(api.palace.mutations.createHall, {
+    wingId, palaceId, type: "facts",
+  });
+  const roomA = await t.mutation(api.palace.mutations.createRoom, {
+    hallId, wingId, palaceId, name: "alpha", summary: "A's room", tags: [], ownerNeopId: "seat_a",
+  });
+  const roomCompany = await t.mutation(api.palace.mutations.createRoom, {
+    hallId, wingId, palaceId, name: "shared", summary: "Company room", tags: [],
+  });
+  const roomB = await t.mutation(api.palace.mutations.createRoom, {
+    hallId, wingId, palaceId, name: "beta", summary: "B's room", tags: [], ownerNeopId: "seat_b",
+  });
+  await t.mutation(api.palace.mutations.markPalaceReady, { palaceId });
+  await t.run(async (ctx: any) => {
+    await ctx.db.insert("neop_permissions", {
+      palaceId,
+      neopId: "seat_a",
+      runtimeOps: ["recall", "remember", "promote", "erase", "audit"],
+      contentAccess: JSON.stringify({ platform: { read: "*", write: "*" } }),
+    });
+  });
+  return { t, palaceId, wingId, hallId, roomA, roomCompany, roomB };
+}
+
+// Seed a closet (+ drawer) inside a room, returning their ids — used to test
+// one-hop closet→room and drawer→room write-guard resolution.
+async function seedClosetDrawer(t: any, palaceId: string, roomId: string) {
+  const r = await t.mutation(api.palace.mutations.createCloset, {
+    palaceId, roomId, content: "owned by B", category: "fact",
+    sourceType: "manual", sourceAdapter: "test", sourceExternalId: "b-seed",
+    authorType: "system", authorId: "test", confidence: 0.9,
+  });
+  await t.mutation(api.palace.mutations.createDrawer, {
+    closetId: r.closetId, palaceId, fact: "B fact", validFrom: 1, confidence: 0.9,
+  });
+  const drawers = await t.query(api.palace.queries.listDrawers, { closetId: r.closetId });
+  return { closetId: r.closetId as string, drawerId: drawers[0]._id as string };
+}
+
+async function call(
+  t: any, tool: string, params: Record<string, unknown>, neopId: string, palaceId: string,
+) {
+  const res = await t.fetch("/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tool, params, neopId, palaceId }),
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+describe("Gate B — seat isolation through /mcp dispatch", () => {
+  // ── WRITE scope (own room only) ─────────────────────────────
+  test("WRITE: seat writes its OWN room → ok", async () => {
+    const { t, palaceId, roomA } = await setupSeatPalace();
+    const { status, json } = await call(t, "palace_add_closet",
+      { roomId: roomA, content: "A decision", category: "decision" }, "seat_a", palaceId);
+    expect(status).toBe(200);
+    expect(json.status).toBe("ok");
+  });
+
+  test("WRITE: seat CANNOT write another seat's room → 403", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { status, json } = await call(t, "palace_add_closet",
+      { roomId: roomB, content: "sneak", category: "decision" }, "seat_a", palaceId);
+    expect(status).toBe(403);
+    expect(json.error).toMatch(/own room/i);
+  });
+
+  test("WRITE: seat CANNOT write a company room (read-only) → 403", async () => {
+    const { t, palaceId, roomCompany } = await setupSeatPalace();
+    const { status } = await call(t, "palace_add_closet",
+      { roomId: roomCompany, content: "x", category: "decision" }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  // ── READ scope (own + company) ──────────────────────────────
+  test("READ: seat can read its OWN room → ok", async () => {
+    const { t, palaceId, roomA } = await setupSeatPalace();
+    const { status } = await call(t, "palace_get_room", { roomId: roomA }, "seat_a", palaceId);
+    expect(status).toBe(200);
+  });
+
+  test("READ: seat can read a COMPANY room → ok", async () => {
+    const { t, palaceId, roomCompany } = await setupSeatPalace();
+    const { status } = await call(t, "palace_get_room", { roomId: roomCompany }, "seat_a", palaceId);
+    expect(status).toBe(200);
+  });
+
+  test("READ: seat CANNOT read another seat's room → 403", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { status } = await call(t, "palace_get_room", { roomId: roomB }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  // ── LIST filter ─────────────────────────────────────────────
+  test("LIST: rooms filtered to own + company; other seat's room hidden", async () => {
+    const { t, palaceId, wingId, roomA, roomCompany, roomB } = await setupSeatPalace();
+    const { status, json } = await call(t, "palace_list_rooms", { wingId }, "seat_a", palaceId);
+    expect(status).toBe(200);
+    const ids = (json.data as any[]).map((r) => r._id);
+    expect(ids).toContain(roomA);
+    expect(ids).toContain(roomCompany);
+    expect(ids).not.toContain(roomB);
+  });
+
+  // ── One-hop resolution: closet→room and drawer→room ─────────
+  test("ERASE: seat CANNOT retract a closet in another seat's room → 403", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { closetId } = await seedClosetDrawer(t, palaceId, roomB);
+    const { status } = await call(t, "palace_retract_closet",
+      { closetId, reason: "nope" }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  test("WRITE: seat CANNOT add a drawer to another seat's closet → 403", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { closetId } = await seedClosetDrawer(t, palaceId, roomB);
+    const { status } = await call(t, "palace_add_drawer",
+      { closetId, fact: "sneak" }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  test("WRITE: seat CANNOT invalidate a drawer in another seat's room → 403", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { drawerId } = await seedClosetDrawer(t, palaceId, roomB);
+    const { status } = await call(t, "palace_invalidate", { drawerId }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  // ── Multi-room writes: tunnel (own from) and merge (own both) ─
+  test("TUNNEL: seat CANNOT create a tunnel FROM another seat's room → 403", async () => {
+    const { t, palaceId, roomA, roomB } = await setupSeatPalace();
+    const { status } = await call(t, "palace_create_tunnel",
+      { fromRoomId: roomB, toRoomId: roomA, relationship: "references" }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  test("MERGE: seat CANNOT merge when it doesn't own both rooms → 403", async () => {
+    const { t, palaceId, roomA, roomB } = await setupSeatPalace();
+    const { status } = await call(t, "palace_merge_rooms",
+      { sourceRoomId: roomB, targetRoomId: roomA }, "seat_a", palaceId);
+    expect(status).toBe(403);
+  });
+
+  // ── Admin bypass ────────────────────────────────────────────
+  test("ADMIN: bypasses seat isolation writing another seat's room → ok", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { status } = await call(t, "palace_add_closet",
+      { roomId: roomB, content: "admin override", category: "decision" }, "_admin", palaceId);
+    expect(status).toBe(200);
   });
 });

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -480,3 +480,63 @@ describe("validators", () => {
     ).not.toThrow();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// Gate B-2: owner-namespaced room resolution (seat-routed remember)
+//
+// palace_remember auto-routes through getOrCreateRoom. Seat isolation is achieved at
+// the ROUTING layer: rooms resolve/create within the caller's owner namespace, so a
+// seat's auto-routed memory can never collide into a company- or another-seat's room.
+// (The full remember action is network-bound; the isolation LOGIC is this pure mutation.)
+// ─────────────────────────────────────────────────────────────────
+
+describe("Gate B-2 — owner-namespaced room resolution", () => {
+  test("same room name under different owners → distinct, correctly-owned rooms", async () => {
+    const t = convexTest(schema);
+    const { palaceId } = await makePalace(t);
+
+    const a1 = await t.mutation(api.palace.mutations.getOrCreateRoom, {
+      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_a",
+    });
+    const b1 = await t.mutation(api.palace.mutations.getOrCreateRoom, {
+      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_b",
+    });
+    expect(a1).not.toEqual(b1);
+
+    const ra = await t.query(api.palace.queries.getRoom, { roomId: a1 });
+    const rb = await t.query(api.palace.queries.getRoom, { roomId: b1 });
+    expect(ra!.ownerNeopId).toBe("seat_a");
+    expect(rb!.ownerNeopId).toBe("seat_b");
+
+    // Idempotent WITHIN an owner namespace.
+    const a2 = await t.mutation(api.palace.mutations.getOrCreateRoom, {
+      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_a",
+    });
+    expect(a2).toEqual(a1);
+  });
+
+  test("a seat does NOT hijack a pre-existing company room of the same name", async () => {
+    const t = convexTest(schema);
+    const { palaceId } = await makePalace(t);
+
+    // Company namespace (admin / bulk-ingest path: no owner) — stable on repeat.
+    const company = await t.mutation(api.palace.mutations.getOrCreateRoom, {
+      palaceId, wingName: "platform", roomName: "shared-topic",
+    });
+    const companyAgain = await t.mutation(api.palace.mutations.getOrCreateRoom, {
+      palaceId, wingName: "platform", roomName: "shared-topic",
+    });
+    expect(companyAgain).toEqual(company);
+
+    // A scoped seat gets its OWN room, not the company one.
+    const seat = await t.mutation(api.palace.mutations.getOrCreateRoom, {
+      palaceId, wingName: "platform", roomName: "shared-topic", ownerNeopId: "seat_a",
+    });
+    expect(seat).not.toEqual(company);
+
+    const rc = await t.query(api.palace.queries.getRoom, { roomId: company });
+    const rs = await t.query(api.palace.queries.getRoom, { roomId: seat });
+    expect(rc!.ownerNeopId).toBeUndefined();   // company namespace preserved (migration-safe)
+    expect(rs!.ownerNeopId).toBe("seat_a");
+  });
+});


### PR DESCRIPTION
Phase-1 seat-isolation ACL on the Convex system-of-record. Companion to NEURAL-ops Gate C (broker, merged) — together they enforce per-room seat isolation across layers.

## Gates in this PR
- **A — room ownership (SoT):** `rooms.ownerNeopId` + `by_palace_owner` index; pure scope predicates in `convex/access/enforce.ts` (`ownsRoom`/`isCompanyRoom`/`canReadRoom`/`canWriteRoom` + `assertNeopScope`/`assertNeopReadScope`/`filterRoomsByReadScope`), read ⊇ write. Set owner = personal room; unset = shared company room. Honest-caller identity (signed `X-NEop-Identity` deferred).
- **B — `/mcp` dispatch guards:** wired into all 9 directly-addressed room tools (get_room READ, list_rooms FILTER, add_closet/add_drawer/invalidate/retract WRITE via 1-hop closet/drawer→room, create_tunnel WRITE-from+READ-to, walk_tunnel READ-entry, merge WRITE-both). Added `getDrawer` accessor.
- **B-2 — seat-routed `remember`:** owner-namespaced room resolution (`by_palace_owner_name`); `getOrCreateRoom`/`createRoom` resolve within the caller's namespace; `ingestExchange` threads `ownerNeopId`; `palace_remember` passes the caller seat (admin → company). Migration-safe/additive.
- **CI:** `.github/workflows/ci.yml` (`npm ci && npm test`).
- **Gate D placeholder:** skipped `acl_graph_no_private_crossseat_edges` keeps the deferred Layer-2 graph gap visible.

## Offline grade
```
vitest: 69 passed | 1 skipped (70)
  - access.test.ts: pure predicates + 13 end-to-end /mcp tests via convex-test t.fetch
    (cross-seat write/read → 403, company-write → 403, list-filter, 1-hop closet/drawer
    denials, admin bypass) + Gate D skipped placeholder
  - palace.test.ts: Phase-1 invariants + Gate B-2 owner-namespacing
no new tsc errors (pre-existing stale-_generated twins/createTunnels noise only)
```

## Known follow-ups (not in this PR)
- **L1 independent enforcement** (direct-call-→403): enforcement currently lives at the `/mcp` dispatch; making the SoT mutations enforce independently when given a caller identity is a deliberate architectural addition — flagged for a design decision, not silently added.
- **Live cross-seat deny** certifies only on the dogfish deploy (convex-test simulates the dispatcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)