### PR TITLE
feat(acl): Gate A+ — L1 SoT independent seat-scope enforcement (defense in depth)

### DIFF
--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -373,3 +373,52 @@ export function filterRoomsByReadScope<T extends RoomScope>(
   if (perms.isAdmin) return rooms;
   return rooms.filter((r) => canReadRoom(perms, r));
 }
+
+// ─── Layer 1: SoT-side independent enforcement (defense in depth) ────────────
+//
+// The room-mutating Convex mutations enforce seat write-scope THEMSELVES when handed
+// a caller identity (`actorNeopId`), independent of the /mcp dispatch guards (Layer 3).
+// This holds the isolation invariant even if a write reaches a mutation WITHOUT going
+// through dispatch — the deepest independence proof — and contains bugs (a dispatch path
+// that forgets to guard).
+//
+// Semantics of `actorNeopId`:
+//   • undefined → TRUSTED internal caller (crons, ingestion pipeline, admin scripts):
+//       no check. Preserves the bare-mutation contract these paths rely on.
+//   • "_admin"  → bypass.
+//   • a seat    → must own the room to write; may read own + company rooms.
+//
+// HONEST-CALLER posture (same as the rest of Phase 1): `actorNeopId` is DECLARED by the
+// caller, not cryptographically authenticated. A malicious direct caller could omit it;
+// this layer defends against accidental cross-seat writes and dispatch-bypass bugs, NOT a
+// forged identity. Signed per-seat identity is deferred to the multi-tenant/adversarial phase.
+
+export function assertActorCanWriteRoom(
+  actorNeopId: string | undefined,
+  room: RoomScope,
+): void {
+  if (actorNeopId === undefined) return;       // trusted internal caller
+  if (actorNeopId === ADMIN_NEOP_ID) return;   // admin bypass
+  if (!(room.ownerNeopId && room.ownerNeopId === actorNeopId)) {
+    throw new AccessDenied(
+      actorNeopId,
+      `SoT write-scope: room owned by "${room.ownerNeopId ?? "(company)"}" is not seat "${actorNeopId}"'s room`,
+    );
+  }
+}
+
+export function assertActorCanReadRoom(
+  actorNeopId: string | undefined,
+  room: RoomScope,
+): void {
+  if (actorNeopId === undefined) return;
+  if (actorNeopId === ADMIN_NEOP_ID) return;
+  const own = !!room.ownerNeopId && room.ownerNeopId === actorNeopId;
+  const company = room.ownerNeopId === undefined || room.ownerNeopId === null;
+  if (!(own || company)) {
+    throw new AccessDenied(
+      actorNeopId,
+      `SoT read-scope: room owned by "${room.ownerNeopId}" is not readable by seat "${actorNeopId}"`,
+    );
+  }
+}

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -199,6 +199,9 @@ async function dispatch(
   const palaceId = params.palaceId as Id<"palaces">;
   const neopId = params.neopId as string;
   const perms = params._perms as ResolvedPermissions;
+  // L1 defense-in-depth: the caller seat threaded into room-mutating mutations so the
+  // SoT enforces seat-scope independently of these dispatch guards (admin → undefined = trusted).
+  const actorNeopId = perms.isAdmin ? undefined : perms.effectiveNeopId;
 
   switch (tool) {
     // ── RECALL ────────────────────────────────────────────
@@ -408,6 +411,7 @@ async function dispatch(
         authorId: neopId,
         confidence: (params.confidence as number) ?? 0.8,
         needsReview: params.needsReview as boolean | undefined,
+        actorNeopId,
       });
     }
 
@@ -422,6 +426,7 @@ async function dispatch(
         fact: params.fact as string,
         validFrom: Date.now(),
         confidence: (params.confidence as number) ?? 0.8,
+        actorNeopId,
       });
     }
 
@@ -449,6 +454,7 @@ async function dispatch(
         relationship: params.relationship as string,
         strength: (params.strength as number) ?? 0.5,
         label: params.label as string | undefined,
+        actorNeopId,
       });
     }
 
@@ -461,6 +467,7 @@ async function dispatch(
       return ctx.runMutation(api.palace.mutations.invalidateDrawer, {
         drawerId: params.drawerId as Id<"drawers">,
         supersededBy: params.supersededBy as Id<"drawers"> | undefined,
+        actorNeopId,
       });
     }
 
@@ -473,6 +480,7 @@ async function dispatch(
         closetId: params.closetId as Id<"closets">,
         reason: params.reason as string,
         retractedBy: neopId,
+        actorNeopId,
       });
     }
 
@@ -486,6 +494,7 @@ async function dispatch(
         palaceId,
         sourceRoomId: params.sourceRoomId as Id<"rooms">,
         targetRoomId: params.targetRoomId as Id<"rooms">,
+        actorNeopId,
       });
     }
 

--- a/convex/palace/mutations.ts
+++ b/convex/palace/mutations.ts
@@ -43,6 +43,12 @@ import {
   safePatchRoom,
   safePatchWing,
 } from "../lib/safePatch.js";
+// Layer-1 SoT-side seat-scope guards (defense in depth, independent of /mcp dispatch).
+// actorNeopId=undefined → trusted internal caller (crons/ingestion); see access/enforce.ts.
+import {
+  assertActorCanWriteRoom,
+  assertActorCanReadRoom,
+} from "../access/enforce.js";
 
 // ─────────────────────────────────────────────────────────────────
 // PALACES
@@ -377,6 +383,7 @@ export const createCloset = mutation({
     visibility: v.optional(v.string()),
     ttlSeconds: v.optional(v.number()),
     needsReview: v.optional(v.boolean()),
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller)
   },
   handler: async (
     ctx,
@@ -400,6 +407,8 @@ export const createCloset = mutation({
     if (room.palaceId !== args.palaceId) {
       throw new Error("room.palaceId mismatch with provided palaceId");
     }
+    // L1 SoT enforcement: a scoped seat may write only its own room.
+    assertActorCanWriteRoom(args.actorNeopId, room);
 
     // ── 3. Compute source-level dedupKey ───────────────────
     // Does NOT include content. Same (adapter, externalId) always produces
@@ -493,10 +502,14 @@ export const retractCloset = mutation({
     closetId: v.id("closets"),
     reason: v.string(),
     retractedBy: v.string(),
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller)
   },
-  handler: async (ctx, { closetId, reason, retractedBy }) => {
+  handler: async (ctx, { closetId, reason, retractedBy, actorNeopId }) => {
     const closet = await ctx.db.get(closetId);
     if (!closet) throw new Error(`closet ${closetId} not found`);
+    // L1 SoT enforcement: write-guard via the closet's owning room.
+    const retractRoom = await ctx.db.get(closet.roomId);
+    if (retractRoom) assertActorCanWriteRoom(actorNeopId, retractRoom);
     if (closet.legalHold) {
       throw new Error(`closet ${closetId} is under legal hold; cannot retract`);
     }
@@ -614,6 +627,7 @@ export const createDrawer = mutation({
     fact: v.string(),
     validFrom: v.number(),
     confidence: v.number(),
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller)
   },
   handler: async (ctx, args): Promise<Id<"drawers">> => {
     validateNonEmpty(args.fact, "fact");
@@ -624,6 +638,9 @@ export const createDrawer = mutation({
     if (closet.palaceId !== args.palaceId) {
       throw new Error("closet.palaceId mismatch");
     }
+    // L1 SoT enforcement: write-guard via the closet's owning room.
+    const drawerRoom = await ctx.db.get(closet.roomId);
+    if (drawerRoom) assertActorCanWriteRoom(args.actorNeopId, drawerRoom);
 
     return await ctx.db.insert("drawers", {
       closetId: args.closetId,
@@ -640,10 +657,14 @@ export const invalidateDrawer = mutation({
   args: {
     drawerId: v.id("drawers"),
     supersededBy: v.optional(v.id("drawers")),
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller)
   },
-  handler: async (ctx, { drawerId, supersededBy }) => {
+  handler: async (ctx, { drawerId, supersededBy, actorNeopId }) => {
     const drawer = await ctx.db.get(drawerId);
     if (!drawer) throw new Error(`drawer ${drawerId} not found`);
+    // L1 SoT enforcement: write-guard via the drawer's owning room.
+    const invalRoom = await ctx.db.get(drawer.roomId);
+    if (invalRoom) assertActorCanWriteRoom(actorNeopId, invalRoom);
 
     await ctx.db.patch(drawerId, {
       validUntil: Date.now(),
@@ -664,6 +685,7 @@ export const createTunnel = mutation({
     relationship: v.string(),
     strength: v.number(),
     label: v.optional(v.string()),
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller)
   },
   handler: async (ctx, args): Promise<Id<"tunnels">> => {
     validateTunnelRelationship(args.relationship);
@@ -677,6 +699,9 @@ export const createTunnel = mutation({
     const toRoom = await ctx.db.get(args.toRoomId);
     if (!fromRoom) throw new Error(`fromRoom ${args.fromRoomId} not found`);
     if (!toRoom) throw new Error(`toRoom ${args.toRoomId} not found`);
+    // L1 SoT enforcement: must OWN the origin room (write) and READ the target.
+    assertActorCanWriteRoom(args.actorNeopId, fromRoom);
+    assertActorCanReadRoom(args.actorNeopId, toRoom);
 
     // Cross-palace isolation: both rooms must belong to the same palace,
     // and that palace must match the provided palaceId.
@@ -705,6 +730,7 @@ export const mergeRooms = mutation({
     palaceId: v.id("palaces"),
     sourceRoomId: v.id("rooms"),
     targetRoomId: v.id("rooms"),
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller)
   },
   handler: async (ctx, args) => {
     if (args.sourceRoomId === args.targetRoomId) {
@@ -718,6 +744,9 @@ export const mergeRooms = mutation({
     if (source.palaceId !== args.palaceId || target.palaceId !== args.palaceId) {
       throw new Error("both rooms must belong to the same palace");
     }
+    // L1 SoT enforcement: destructive cross-room write — must OWN both rooms.
+    assertActorCanWriteRoom(args.actorNeopId, source);
+    assertActorCanWriteRoom(args.actorNeopId, target);
 
     // Move all closets from source to target.
     const closets = await ctx.db

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -532,6 +532,100 @@ describe("Gate B — seat isolation through /mcp dispatch", () => {
 // is gated on the live FalkorDB backend, so it is not part of the offline suite.
 // ─────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────
+// Gate A+ / L1: SoT-side INDEPENDENT enforcement. Calls the Convex mutations
+// DIRECTLY (no /mcp dispatch) with an actorNeopId — proves seat isolation holds
+// even when Layer 3 is bypassed (the deepest independence proof), AND that
+// actorNeopId=undefined still lets trusted internal callers (crons/ingestion) through.
+// ─────────────────────────────────────────────────────────────────
+
+const closetArgs = (palaceId: string, roomId: string, actorNeopId?: string) => ({
+  palaceId, roomId, content: "direct-call content", category: "decision",
+  sourceType: "manual", sourceAdapter: "test", sourceExternalId: `direct-${roomId}-${actorNeopId ?? "trusted"}`,
+  authorType: "system", authorId: "test", confidence: 0.8,
+  ...(actorNeopId !== undefined ? { actorNeopId } : {}),
+});
+
+describe("Gate A+ — L1 SoT independent enforcement (direct mutation calls)", () => {
+  test("createCloset DIRECT into another seat's room → denied (L3 bypassed)", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    await expect(
+      t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomB, "seat_a") as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+
+  test("createCloset DIRECT into own room → allowed", async () => {
+    const { t, palaceId, roomA } = await setupSeatPalace();
+    const r = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomA, "seat_a") as any);
+    expect(r.status).toBe("created");
+  });
+
+  test("createCloset DIRECT into a company room → denied (company is read-only for a seat)", async () => {
+    const { t, palaceId, roomCompany } = await setupSeatPalace();
+    await expect(
+      t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomCompany, "seat_a") as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+
+  test("createCloset DIRECT with NO actorNeopId → allowed (trusted internal caller preserved)", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const r = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomB) as any);
+    expect(r.status).toBe("created"); // crons/ingestion still write anywhere
+  });
+
+  test("createCloset DIRECT with actorNeopId=_admin → allowed (admin bypass)", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const r = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomB, "_admin") as any);
+    expect(r.status).toBe("created");
+  });
+
+  test("createDrawer DIRECT into another seat's closet → denied (closet→room)", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { closetId } = await seedClosetDrawer(t, palaceId, roomB);
+    await expect(
+      t.mutation(api.palace.mutations.createDrawer, {
+        closetId, palaceId, fact: "x", validFrom: 1, confidence: 0.9, actorNeopId: "seat_a",
+      } as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+
+  test("invalidateDrawer DIRECT in another seat's room → denied (drawer→room)", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { drawerId } = await seedClosetDrawer(t, palaceId, roomB);
+    await expect(
+      t.mutation(api.palace.mutations.invalidateDrawer, { drawerId, actorNeopId: "seat_a" } as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+
+  test("retractCloset DIRECT in another seat's room → denied", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { closetId } = await seedClosetDrawer(t, palaceId, roomB);
+    await expect(
+      t.mutation(api.palace.mutations.retractCloset, {
+        closetId, reason: "x", retractedBy: "seat_a", actorNeopId: "seat_a",
+      } as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+
+  test("createTunnel DIRECT from another seat's room → denied", async () => {
+    const { t, palaceId, roomA, roomB } = await setupSeatPalace();
+    await expect(
+      t.mutation(api.palace.mutations.createTunnel, {
+        palaceId, fromRoomId: roomB, toRoomId: roomA, relationship: "references", strength: 0.5, actorNeopId: "seat_a",
+      } as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+
+  test("mergeRooms DIRECT not owning both → denied", async () => {
+    const { t, palaceId, roomA, roomB } = await setupSeatPalace();
+    await expect(
+      t.mutation(api.palace.mutations.mergeRooms, {
+        palaceId, sourceRoomId: roomB, targetRoomId: roomA, actorNeopId: "seat_a",
+      } as any),
+    ).rejects.toThrow(/SoT write-scope/i);
+  });
+});
+
 describe("Gate D — graph seat isolation (DEFERRED)", () => {
   test.skip("acl_graph_no_private_crossseat_edges", () => {
     // WHEN un-skipped (post-decision to seat-isolate the graph):


### PR DESCRIPTION
Closes the last correctness hole in the isolation story: the room-mutating Convex mutations now enforce seat write-scope **themselves** when handed a caller identity — independent of the `/mcp` dispatch (Layer 3). Proves the SoT holds even when L3 is bypassed.

## Change
- `access/enforce.ts`: `assertActorCanWriteRoom` / `assertActorCanReadRoom`. `actorNeopId`: **undefined = trusted** internal caller (crons/ingestion/admin scripts — no check, preserves the bare-mutation contract); `_admin` = bypass; a seat = must own to write, may read own + company.
- `mutations.ts`: `createCloset`, `createDrawer`, `createTunnel`, `mergeRooms`, `retractCloset`, `invalidateDrawer` gain an optional `actorNeopId` and guard after resolving their room(s) (closet→room / drawer→room one-hop; tunnel = write-from + read-to; merge = write-both).
- `http.ts`: dispatch threads `actorNeopId = perms.isAdmin ? undefined : perms.effectiveNeopId` into all six → production **double-enforces** (dispatch + SoT) = defense in depth.

## Offline grade
```
vitest 79 pass | 1 skip  (+10 direct-call tests)
  - createCloset/createDrawer/invalidate/retract/createTunnel/mergeRooms DIRECT,
    cross-seat (actorNeopId set, no /mcp) → denied (SoT write-scope)
  - own-room → allowed ; NO actorNeopId → allowed (trusted caller preserved) ; _admin → allowed
  - palace.test.ts (22) still green — mutations called with no actor = trusted
no new tsc errors
```

## Honest-caller caveat
`actorNeopId` is declared by the caller, not cryptographically authenticated — a malicious **direct** caller could still omit it. This layer defends accidental cross-seat writes + dispatch-bypass bugs, not a forged identity. Signed per-seat identity stays deferred to the multi-tenant/adversarial phase (consistent with the rest of Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)