### PR TITLE
feat(acl): S0.3 Phase A — additive _system trusted-internal actor + completeness guard

### DIFF
--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -15,7 +15,7 @@
 //   - Scope bindings block conflicting filters (not just inject defaults)
 
 import type { Id, Doc } from "../_generated/dataModel.js";
-import { ADMIN_NEOP_ID } from "../lib/enums.js";
+import { ADMIN_NEOP_ID, SYSTEM_NEOP_ID } from "../lib/enums.js";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -383,10 +383,21 @@ export function filterRoomsByReadScope<T extends RoomScope>(
 // that forgets to guard).
 //
 // Semantics of `actorNeopId`:
-//   • undefined → TRUSTED internal caller (crons, ingestion pipeline, admin scripts):
-//       no check. Preserves the bare-mutation contract these paths rely on.
+//   • undefined → TRUSTED internal caller: no check. *** PHASE A (current) ***
+//       This is the LEGACY fail-OPEN contract. It flips to DENY in PHASE B once every
+//       internal write path passes an explicit actor and the completeness guard
+//       (tests/actor_coverage.test.ts) is green. DO NOT rely on undefined for new code —
+//       trusted internal paths must pass SYSTEM_NEOP_ID ("_system") instead.
+//   • "_system" → TRUSTED internal actor (crons, ingestion pipeline, seed scripts): no
+//       check. An ELEVATED identity, never derivable from request input, always audited.
+//       Same family as "_admin". This is the EXPLICIT, Phase-B-safe form of the trusted
+//       internal caller — it survives the undefined⇒DENY flip.
 //   • "_admin"  → bypass.
 //   • a seat    → must own the room to write; may read own + company rooms.
+//
+// PHASE A is ADDITIVE: undefined is STILL trusted; "_system" is allowed ALONGSIDE it. No
+// existing caller changes behavior. PHASE B (the breaking flip: undefined ⇒ DENY) is gated
+// on the completeness guard proving zero remaining undefined-relying internal callers.
 //
 // HONEST-CALLER posture (same as the rest of Phase 1): `actorNeopId` is DECLARED by the
 // caller, not cryptographically authenticated. A malicious direct caller could omit it;
@@ -397,8 +408,9 @@ export function assertActorCanWriteRoom(
   actorNeopId: string | undefined,
   room: RoomScope,
 ): void {
-  if (actorNeopId === undefined) return;       // trusted internal caller
-  if (actorNeopId === ADMIN_NEOP_ID) return;   // admin bypass
+  if (actorNeopId === undefined) return;        // Phase A: still trusted (flips to DENY in Phase B)
+  if (actorNeopId === SYSTEM_NEOP_ID) return;   // trusted internal actor (elevated)
+  if (actorNeopId === ADMIN_NEOP_ID) return;    // admin bypass
   if (!(room.ownerNeopId && room.ownerNeopId === actorNeopId)) {
     throw new AccessDenied(
       actorNeopId,
@@ -411,8 +423,9 @@ export function assertActorCanReadRoom(
   actorNeopId: string | undefined,
   room: RoomScope,
 ): void {
-  if (actorNeopId === undefined) return;
-  if (actorNeopId === ADMIN_NEOP_ID) return;
+  if (actorNeopId === undefined) return;        // Phase A: still trusted (flips to DENY in Phase B)
+  if (actorNeopId === SYSTEM_NEOP_ID) return;   // trusted internal actor (elevated)
+  if (actorNeopId === ADMIN_NEOP_ID) return;    // admin bypass
   const own = !!room.ownerNeopId && room.ownerNeopId === actorNeopId;
   const company = room.ownerNeopId === undefined || room.ownerNeopId === null;
   if (!(own || company)) {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -439,6 +439,7 @@ async function dispatch(
         roomName: params.roomName as string,
         summary: params.summary as string | undefined,
         ownerNeopId: perms.isAdmin ? undefined : perms.effectiveNeopId,
+        actorNeopId, // L1 SoT write-scope: a scoped seat may only create in its OWN namespace (admin ⇒ undefined ⇒ bypass)
       });
 
     case "palace_create_tunnel": {

--- a/convex/ingestion/ingest.ts
+++ b/convex/ingestion/ingest.ts
@@ -22,7 +22,7 @@ import { scanForPII } from "./pii.js";
 import { routeToWing, routeToRoom, classifyCategory, scoreConfidence } from "./route.js";
 import { embedOne, EMBEDDING_MODEL } from "../lib/qwen.js";
 import { callGeminiLlm } from "../lib/geminiLlm.js";
-import { CATEGORIES } from "../lib/enums.js";
+import { CATEGORIES, SYSTEM_NEOP_ID } from "../lib/enums.js";
 import { EXTRACTION_SYSTEM_PROMPT, parseExtractionResponse, type ExtractionItem } from "./extract.js";
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -131,6 +131,7 @@ export const ingestExchange = action({
             roomName: item.room,
             summary: item.title,
             ownerNeopId: args.ownerNeopId,   // seat-isolation: route to the caller's namespace
+            actorNeopId: SYSTEM_NEOP_ID,     // trusted internal pipeline (elevated, audited)
           },
         );
 
@@ -152,6 +153,7 @@ export const ingestExchange = action({
             confidence: item.confidence,
             piiTags,
             needsReview: item.wing === "_quarantine" || extractionFailed,
+            actorNeopId: SYSTEM_NEOP_ID,     // trusted internal pipeline (elevated, audited)
           },
         );
 
@@ -169,6 +171,7 @@ export const ingestExchange = action({
               fact,
               validFrom: args.timestamp,
               confidence: item.confidence,
+              actorNeopId: SYSTEM_NEOP_ID,   // trusted internal pipeline (elevated, audited)
             });
             drawersCreated++;
           } catch (e) {

--- a/convex/lib/enums.ts
+++ b/convex/lib/enums.ts
@@ -92,6 +92,12 @@ export const KG_BACKED_CATEGORIES = new Set<Category>([
 
 export const ADMIN_NEOP_ID = "_admin";
 
+// Trusted-internal actor (crons / ingestion pipeline / seed scripts).
+// An ELEVATED identity: never derivable from request input, always audited.
+// Same family as `_admin`. Used as the write-guard actor for trusted internal
+// write paths so they remain explicit (and survive the Phase-B undefined⇒DENY flip).
+export const SYSTEM_NEOP_ID = "_system";
+
 // ───── Convex document size guard ─────
 
 // Convex enforces a 1MB document limit. Leave headroom for metadata.

--- a/convex/palace/mutations.ts
+++ b/convex/palace/mutations.ts
@@ -254,8 +254,14 @@ export const getOrCreateRoom = mutation({
     roomName: v.string(),
     summary: v.optional(v.string()),
     ownerNeopId: v.optional(v.string()),   // seat-isolation: stamp personal ownership on create
+    actorNeopId: v.optional(v.string()),   // L1 seat-scope (undefined = trusted caller; "_system" = trusted internal)
   },
   handler: async (ctx, args): Promise<Id<"rooms">> => {
+    // L1 SoT-side write-scope (defense in depth): a scoped seat may only resolve/create
+    // a room in its OWN (or the company) namespace. undefined/"_system"/"_admin" bypass
+    // (trusted internal + admin). The room being resolved/created is owned by ownerNeopId.
+    assertActorCanWriteRoom(args.actorNeopId, { ownerNeopId: args.ownerNeopId });
+
     // Normalize names.
     const wn = args.wingName.toLowerCase().replace(/\s+/g, "-");
     const rn = args.roomName.toLowerCase().replace(/\s+/g, "-");

--- a/scripts/createTunnels.ts
+++ b/scripts/createTunnels.ts
@@ -75,6 +75,7 @@ async function main() {
         relationship: relationship as any,
         strength,
         label: `${fromWing}/${fromRoom} → ${toWing}/${toRoom}`,
+        actorNeopId: "_system", // trusted internal seed script (elevated, audited)
       });
       console.log(`  OK: ${fromWing}/${fromRoom} → ${toWing}/${toRoom} (${relationship}, ${strength})`);
       created++;

--- a/scripts/ingestArchive.ts
+++ b/scripts/ingestArchive.ts
@@ -233,6 +233,7 @@ async function main() {
               wingName: wing,
               roomName: room,
               summary: `${folder}/${file}`,
+              actorNeopId: "_system", // trusted internal import script (elevated, audited)
             },
           );
 
@@ -250,6 +251,7 @@ async function main() {
               authorType: "system",
               authorId: "archive-import",
               confidence: 0.9,
+              actorNeopId: "_system", // trusted internal import script (elevated, audited)
             } as any,
           );
 
@@ -268,6 +270,7 @@ async function main() {
               fact,
               validFrom: Date.now(),
               confidence: 0.85,
+              actorNeopId: "_system", // trusted internal import script (elevated, audited)
             });
           }
 

--- a/tests/actor_coverage.test.ts
+++ b/tests/actor_coverage.test.ts
@@ -1,0 +1,138 @@
+// ─── Phase-A → Phase-B completeness guard (S0.3 _system actor flip) ───────────
+//
+// This is the GATE for the breaking flip. Today (Phase A), the SoT write/read
+// predicates in convex/access/enforce.ts treat `actorNeopId === undefined` as a
+// TRUSTED internal caller (fail-OPEN). Phase B flips that branch to DENY.
+//
+// That flip is SAFE *only* when every internal call site of the guarded room
+// mutations passes an explicit `actorNeopId` (a seat, "_admin", or the trusted
+// internal "_system") — otherwise the flip would break a path that silently
+// relied on undefined-⇒-trusted.
+//
+// This test reads the actual source (convex/ + scripts/, excluding _generated,
+// node_modules, and test files) and asserts that EVERY call to a guarded
+// mutation passes an `actorNeopId` argument. It MUST be green before Phase B is
+// undertaken. After the Phase-A migration it passes; before it, it would fail.
+
+import { describe, expect, test } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// Repo root is one level up from tests/.
+const ROOT = resolve(__dirname, "..");
+
+// The guarded room mutations (+ getOrCreateRoom) whose call sites must carry an
+// explicit actor for the Phase-B flip to be safe.
+const GUARDED = [
+  "createCloset",
+  "createDrawer",
+  "createTunnel",
+  "mergeRooms",
+  "retractCloset",
+  "invalidateDrawer",
+  "getOrCreateRoom",
+] as const;
+
+// Source roots to scan, and what to exclude.
+const SCAN_DIRS = ["convex", "scripts"];
+const EXCLUDE_DIR_RE = /(^|\/)(_generated|node_modules)(\/|$)/;
+const EXCLUDE_FILE_RE = /\.test\.ts$/;
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    const rel = full.slice(ROOT.length + 1);
+    if (EXCLUDE_DIR_RE.test(rel)) continue;
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (full.endsWith(".ts") && !EXCLUDE_FILE_RE.test(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// From `start`, find the next `{`-delimited object literal and return its
+// balanced body. The two call shapes we must handle both put the args object
+// immediately after the mutation reference:
+//   • api.palace.mutations.createCloset, { ...args... }   (runMutation(ref, obj))
+//   • api.palace.mutations.createCloset({ ...args... })   (client.mutation(ref, obj) / direct)
+// We scan to the first `{` after the reference and capture to its matching `}`,
+// tracking depth so a multi-line / nested object is captured whole.
+function nextObjectBody(src: string, start: number): string | null {
+  const open = src.indexOf("{", start);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return src.slice(open + 1, i);
+    }
+  }
+  // Unbalanced — return the rest; the assertion will then flag it loudly.
+  return src.slice(open + 1);
+}
+
+interface CallSite {
+  file: string;
+  line: number;
+  fn: string;
+  hasActor: boolean;
+}
+
+function findCallSites(file: string): CallSite[] {
+  const src = readFileSync(file, "utf8");
+  const sites: CallSite[] = [];
+  for (const fn of GUARDED) {
+    // Match the mutation reference as a property access, e.g.
+    // `api.palace.mutations.createCloset` or `mutations.createCloset`. We anchor
+    // on `.${fn}` so the mutation *definitions* in convex/palace/mutations.ts
+    // (`export const createCloset = mutation({`, no leading dot) are NOT matched.
+    // A following `(` or `,` distinguishes a real reference from a substring.
+    const re = new RegExp(`\\.${fn}\\s*[(,]`, "g");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) {
+      const body = nextObjectBody(src, m.index);
+      const line = src.slice(0, m.index).split("\n").length;
+      // Accept both `actorNeopId: <value>` and ES6 shorthand `actorNeopId` (a
+      // bare property terminated by comma / newline / closing brace).
+      const hasActor =
+        body !== null && /\bactorNeopId\s*(:|,|\}|$|[\r\n])/.test(body);
+      sites.push({ file: file.slice(ROOT.length + 1), line, fn, hasActor });
+    }
+  }
+  return sites;
+}
+
+const ALL_SITES: CallSite[] = SCAN_DIRS.flatMap((d) =>
+  listSourceFiles(join(ROOT, d)).flatMap(findCallSites),
+);
+
+describe("Phase-A actor coverage (Phase-B flip gate)", () => {
+  test("the scan finds the known guarded call sites (self-check)", () => {
+    // Sanity: ensure the scanner is actually wired and finding call sites, so a
+    // future regression in the scanner can't make this guard vacuously pass.
+    expect(ALL_SITES.length).toBeGreaterThan(0);
+  });
+
+  test("every guarded mutation call site passes an explicit actorNeopId", () => {
+    const missing = ALL_SITES.filter((s) => !s.hasActor).map(
+      (s) => `${s.file}:${s.line} → ${s.fn}() is missing actorNeopId`,
+    );
+    expect(
+      missing,
+      `These internal callers rely on undefined-⇒-trusted and would break the ` +
+        `Phase-B undefined⇒DENY flip:\n${missing.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Phase A of the fail-closed flip — additive, non-breaking.** Sets up the safe two-step the reviewer locked: migrate first, flip later.

## What
- `_system` trusted-internal actor (`SYSTEM_NEOP_ID`, enums.ts), mirroring `_admin`. The SoT guards (`assertActorCanWrite/ReadRoom`) allow `_system`; **`undefined` is STILL allowed** (marked *"flips to DENY in Phase B"*) — no behavior change for existing callers.
- Every internal caller migrated to pass an explicit actor: `ingestExchange` → `_system` (trusted pipeline), `scripts/createTunnels` + `scripts/ingestArchive`, plus the dispatch thread in `http.ts`.
- **Completeness guard `tests/actor_coverage.test.ts`** (the Phase-A→B gate): scans `convex/` + `scripts/` source and asserts every guarded-mutation call site (`createCloset/Drawer/Tunnel`, `mergeRooms`, `retract`, `invalidate`, `getOrCreateRoom`) passes an `actorNeopId`. Green now; would fail if any caller omitted it.

## Offline grade
`vitest 81 pass | 1 skip` (added 2; pre-existing 80/1 unchanged & green).

## ⚠️ Before Phase B is run (NOT in this PR — gated on live dogfish validation)
Two things must be handled or Phase B breaks admin:
1. `http.ts:204` threads `actorNeopId = perms.isAdmin ? undefined : …` — i.e. **`undefined` for admin.** Flipping `undefined → DENY` would deny admin writes. Phase B must change this to thread `_admin`/`_system`.
2. The completeness guard checks *arg presence*, not *value*; it won't catch (1). Phase B should also assert the threaded value is never `undefined` on the admin branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)