### PR TITLE
fix(acl): #2 — make Phase B safe (thread _admin not undefined) + provenance guard

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -15,6 +15,7 @@ import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server.js";
 import { api, internal } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
+import { ADMIN_NEOP_ID } from "./lib/enums.js";
 import {
   type ResolvedPermissions,
   resolvePermissions,
@@ -199,9 +200,12 @@ async function dispatch(
   const palaceId = params.palaceId as Id<"palaces">;
   const neopId = params.neopId as string;
   const perms = params._perms as ResolvedPermissions;
-  // L1 defense-in-depth: the caller seat threaded into room-mutating mutations so the
-  // SoT enforces seat-scope independently of these dispatch guards (admin → undefined = trusted).
-  const actorNeopId = perms.isAdmin ? undefined : perms.effectiveNeopId;
+  // L1 defense-in-depth: the caller seat threaded into room-mutating mutations so the SoT
+  // enforces seat-scope independently of these dispatch guards. SERVER-DERIVED only (from the
+  // resolved perms — never from request input). Admin threads the explicit ADMIN_NEOP_ID, NOT
+  // `undefined`: the S0.3 Phase-B flip makes `undefined ⇒ DENY`, and threading undefined for
+  // admin would deny every admin write. The actor here is provably non-undefined.
+  const actorNeopId: string = perms.isAdmin ? ADMIN_NEOP_ID : perms.effectiveNeopId;
 
   switch (tool) {
     // ── RECALL ────────────────────────────────────────────

--- a/tests/actor_coverage.test.ts
+++ b/tests/actor_coverage.test.ts
@@ -88,6 +88,26 @@ interface CallSite {
   line: number;
   fn: string;
   hasActor: boolean;
+  actorValue: string | null;   // the expression passed as actorNeopId, for provenance
+}
+
+// PROVENANCE allowlist (the Phase-B sharpening): the actor threaded into a guarded
+// mutation must be SERVER-DERIVED — a resolved-perms variable or a trusted-actor
+// constant — never a request-controlled expression. "Not undefined" stops the admin
+// outage; this stops a future client-claimed `_admin`/seat from riding the same arg.
+const SERVER_DERIVED_ACTOR =
+  /^(actorNeopId|SYSTEM_NEOP_ID|ADMIN_NEOP_ID|"_system"|"_admin"|'_system'|'_admin')$/;
+// Request-derived tokens that must NEVER appear in an actor value or its definition.
+const REQUEST_DERIVED = /\b(params|body|request|headers?)\b/;
+
+// Extract the value expression passed as actorNeopId from a captured object body.
+// Handles `actorNeopId: <expr>,` (strips trailing comment) and ES6 shorthand `actorNeopId`.
+function extractActorValue(body: string | null): string | null {
+  if (body === null) return null;
+  const kv = body.match(/\bactorNeopId\s*:\s*([^,\n}]+)/);
+  if (kv && kv[1] !== undefined) return kv[1].replace(/\/\/.*$/, "").trim();
+  if (/\bactorNeopId\s*(,|\}|$|[\r\n])/.test(body)) return "actorNeopId"; // shorthand → the var
+  return null;
 }
 
 function findCallSites(file: string): CallSite[] {
@@ -108,7 +128,10 @@ function findCallSites(file: string): CallSite[] {
       // bare property terminated by comma / newline / closing brace).
       const hasActor =
         body !== null && /\bactorNeopId\s*(:|,|\}|$|[\r\n])/.test(body);
-      sites.push({ file: file.slice(ROOT.length + 1), line, fn, hasActor });
+      sites.push({
+        file: file.slice(ROOT.length + 1), line, fn, hasActor,
+        actorValue: extractActorValue(body),
+      });
     }
   }
   return sites;
@@ -134,5 +157,51 @@ describe("Phase-A actor coverage (Phase-B flip gate)", () => {
       `These internal callers rely on undefined-⇒-trusted and would break the ` +
         `Phase-B undefined⇒DENY flip:\n${missing.join("\n")}`,
     ).toEqual([]);
+  });
+
+  // ── Provenance (the Phase-B sharpening) ─────────────────────────────────────
+  // "Not undefined" prevents the admin outage; these two assert the actor is
+  // SERVER-DERIVED and correct-for-path, so a client-claimed actor can't ride the
+  // same arg. (Upstream identity is still client-asserted until edge-auth / #1+#3 —
+  // this proves the dispatch→SoT thread itself carries no request input.)
+
+  test("every threaded actorNeopId VALUE is server-derived (never request input)", () => {
+    const bad = ALL_SITES
+      .filter((s) => s.hasActor)
+      .filter(
+        (s) =>
+          s.actorValue === null ||
+          !SERVER_DERIVED_ACTOR.test(s.actorValue) ||
+          REQUEST_DERIVED.test(s.actorValue),
+      )
+      .map((s) => `${s.file}:${s.line} → ${s.fn}() actorNeopId=${s.actorValue ?? "(unparsed)"}`);
+    expect(
+      bad,
+      `actorNeopId must be a server-derived var/constant, not request input:\n${bad.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  test("the threaded actorNeopId variable is derived from resolved perms, not request input", () => {
+    // The shorthand call sites pass the `actorNeopId` var; prove its definition(s)
+    // come from `perms.` and contain no params/body/request/header tokens.
+    const defs: { where: string; rhs: string }[] = [];
+    const bad: string[] = [];
+    for (const file of SCAN_DIRS.flatMap((d) => listSourceFiles(join(ROOT, d)))) {
+      const src = readFileSync(file, "utf8");
+      const re = /\b(?:const|let)\s+actorNeopId\b[^=]*=\s*([^;]+);/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src)) !== null) {
+        const rhs = (m[1] ?? "").trim();
+        const line = src.slice(0, m.index).split("\n").length;
+        const where = `${file.slice(ROOT.length + 1)}:${line}`;
+        defs.push({ where, rhs });
+        if (!/\bperms\./.test(rhs) || REQUEST_DERIVED.test(rhs)) {
+          bad.push(`${where} → const actorNeopId = ${rhs}`);
+        }
+      }
+    }
+    // Self-check: the dispatch's actorNeopId definition must exist (guard not vacuous).
+    expect(defs.length, "no `const actorNeopId =` found to verify").toBeGreaterThan(0);
+    expect(bad, `actorNeopId must derive from resolved perms:\n${bad.join("\n")}`).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes gap #2 from the end-to-end review — a one-line trap that would turn the S0.3 Phase-B flip into an admin outage, invisible to the existing guard.

## The bug
`http.ts` threaded `actorNeopId = perms.isAdmin ? undefined : perms.effectiveNeopId`. Phase B (`undefined ⇒ DENY`) would deny **every admin write through /mcp**, and `actor_coverage` (arg-presence only) stayed green.

## Fixes
1. **`http.ts`** — admin threads explicit `ADMIN_NEOP_ID` (server-derived, non-undefined). Non-breaking today; Phase-B-safe. (Lines 382/441 are `ownerNeopId`, where `undefined`=company room is correct — untouched.)
2. **Guard sharpened to provenance** — from "arg present" to "arg is **server-derived**":
   - every threaded `actorNeopId` value ∈ {`actorNeopId` var, `SYSTEM_NEOP_ID`/`ADMIN_NEOP_ID`, `"_system"`/`"_admin"`}, with no `params`/`body`/`request`/`header`;
   - the `const actorNeopId = …` definition must derive from `perms.`, never request input.
   Proven non-vacuous (rejects `params.neopId`/`body.neopId`, accepts server-derived).

## Scope (honest)
This makes the dispatch→SoT thread provably carry **no request input**, and unblocks Phase B. It does **not** close the upstream client-asserted identity — a request claiming `neopId="_admin"` still resolves `isAdmin`. That's **edge-auth (gaps #1/#3)**, still the milestone; #2 is the safe partner, not a substitute.

`vitest 83 pass | 1 skip`; no new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)