### PR TITLE
fix(acl): #4 — retract erasure cascade to drawers + audited erasure event

### DIFF
--- a/convex/palace/mutations.ts
+++ b/convex/palace/mutations.ts
@@ -551,12 +551,49 @@ export const retractCloset = mutation({
       });
     }
 
-    // Audit trail (caller should also write an explicit audit_event with op=retract).
+    // ── GDPR cascade (#4): the closet's atomic facts (drawers) carry the same PII
+    // as the closet — redact + invalidate them too, or erasure is incomplete. Scoped
+    // to THIS closet's drawers. The closet's legalHold (checked above) gates the cascade.
+    const drawers = await ctx.db
+      .query("drawers")
+      .withIndex("by_closet", (q) => q.eq("closetId", closetId))
+      .collect();
+    const erasedAt = Date.now();
+    const graphitiPending: string[] = [];
+    for (const d of drawers) {
+      if (d.graphitiNodeId) graphitiPending.push(d.graphitiNodeId);
+      await ctx.db.patch(d._id, { fact: "[REDACTED]", validUntil: erasedAt });
+    }
+
+    // Audited erasure event (#4; threaded into audit_events, the sink #12 will unify):
+    // erasure that isn't traceable is its own compliance hole. graphitiPendingDeletion
+    // records the cross-service (FalkorDB) nodes still to remove — that path is gap #5,
+    // not yet wired, so this leaves a durable to-do trail instead of a silent omission.
+    await ctx.db.insert("audit_events", {
+      palaceId: closet.palaceId,
+      op: "retract",
+      neopId: retractedBy,
+      effectiveNeopId: actorNeopId ?? retractedBy,
+      status: "ok",
+      latencyMs: 0,
+      timestamp: erasedAt,
+      itemId: closetId,
+      extra: JSON.stringify({
+        action: "retract_cascade",
+        reason: reason.slice(0, 200),
+        contentRedacted: true,
+        embeddingDeleted: !!emb,
+        drawersRedacted: drawers.length,
+        graphitiPendingDeletion: graphitiPending,
+      }),
+    });
+
     return {
       status: "ok" as const,
       closetId,
       reason: reason.slice(0, 200),
       retractedBy,
+      drawersRedacted: drawers.length,
     };
   },
 });

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -540,3 +540,53 @@ describe("Gate B-2 — owner-namespaced room resolution", () => {
     expect(rs!.ownerNeopId).toBe("seat_a");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// #4 — GDPR erasure cascade: retract must also redact the closet's drawers
+// (same PII) and write a traceable audit event. Erasure that leaves the facts
+// or isn't auditable is a compliance hole.
+// ─────────────────────────────────────────────────────────────────
+
+describe("#4 — retract erasure cascade + audit", () => {
+  test("retract redacts + invalidates the closet's drawers and writes an audited erasure event", async () => {
+    const t = convexTest(schema);
+    const { palaceId, roomId } = await makePalace(t);
+    const r = await t.mutation(api.palace.mutations.createCloset, baseClosetArgs(palaceId, roomId) as any);
+    await t.mutation(api.palace.mutations.createDrawer, {
+      closetId: r.closetId, palaceId, fact: "sensitive PII fact", validFrom: 1, confidence: 0.9,
+    });
+
+    const res = await t.mutation(api.palace.mutations.retractCloset, {
+      closetId: r.closetId, reason: "GDPR erase", retractedBy: "_admin",
+    });
+    expect(res.drawersRedacted).toBe(1);
+
+    // The drawer's fact is unrecoverable AND marked invalid.
+    const drawers = await t.query(api.palace.queries.listDrawers, { closetId: r.closetId });
+    expect(drawers.length).toBe(1);
+    expect(drawers[0]!.fact).toBe("[REDACTED]");
+    expect(drawers[0]!.validUntil).toBeDefined();
+
+    // A traceable erasure audit row exists with the cascade specifics.
+    const audits = await t.run(async (ctx: any) =>
+      ctx.db.query("audit_events").withIndex("by_palace", (q: any) => q.eq("palaceId", palaceId)).collect());
+    const erase = audits.find((a: any) => a.op === "retract" && a.itemId === r.closetId);
+    expect(erase, "an op=retract audit_event must be written for the closet").toBeDefined();
+    const extra = JSON.parse(erase.extra);
+    expect(extra.drawersRedacted).toBe(1);
+    expect(extra.contentRedacted).toBe(true);
+  });
+
+  test("retract with no drawers still writes an audit event (drawersRedacted=0)", async () => {
+    const t = convexTest(schema);
+    const { palaceId, roomId } = await makePalace(t);
+    const r = await t.mutation(api.palace.mutations.createCloset, baseClosetArgs(palaceId, roomId) as any);
+    const res = await t.mutation(api.palace.mutations.retractCloset, {
+      closetId: r.closetId, reason: "x", retractedBy: "_admin",
+    });
+    expect(res.drawersRedacted).toBe(0);
+    const audits = await t.run(async (ctx: any) =>
+      ctx.db.query("audit_events").withIndex("by_palace", (q: any) => q.eq("palaceId", palaceId)).collect());
+    expect(audits.some((a: any) => a.op === "retract" && a.itemId === r.closetId)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes gap #4 — incomplete GDPR erasure + untraceable erasure.

`retractCloset` redacted the closet content + dropped its embedding, but **left the drawers** (atomic facts with the same PII) and wrote **no erasure audit** (the code even said a caller "should also write an explicit audit_event").

- **Cascade** (this closet's drawers only): `fact → "[REDACTED]"` + `validUntil` set. Gated by the closet's `legalHold`.
- **Audited erasure event** in `audit_events` (`op=retract`, `itemId=closetId`) with `reason`, `contentRedacted`, `embeddingDeleted`, `drawersRedacted`, and **`graphitiPendingDeletion`** — the FalkorDB node ids still to remove. The graph-deletion path is **gap #5** (not yet wired); recording the ids leaves a durable to-do trail instead of a silent cross-service hole. Threaded into `audit_events` so it rides #12's unified sink.

`vitest 85 pass | 1 skip` (+2); no new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)