### PR TITLE
feat(edge-auth): #1/#3 E1 — seat_bindings store (only source of requester identity)

### DIFF
--- a/convex/access/bindings.ts
+++ b/convex/access/bindings.ts
@@ -1,0 +1,64 @@
+// Edge-auth E1 — human↔seat binding store (#1/#3). The ONLY source of requester identity.
+//
+// resolveBinding(mxid) is what the edge resolver (NEURAL-ops acp/edge_auth) calls after the
+// Application-Service verifies the mxid. Bindings are provisioned per tenant; upsertSeatBinding
+// is deliberately NOT registered as an /mcp tool, so a channel path can never write a binding.
+// Write-time validation enforces the core invariant: a human is NEVER bound to a reserved,
+// server-minted identity (_admin/_system/_*).
+
+import { query, mutation } from "../_generated/server.js";
+import { v } from "convex/values";
+import { isReservedIdentity } from "../lib/enums.js";
+
+export const resolveBinding = query({
+  args: { mxid: v.string() },
+  handler: async (ctx, { mxid }) => {
+    return await ctx.db
+      .query("seat_bindings")
+      .withIndex("by_mxid", (q) => q.eq("mxid", mxid))
+      .first();
+  },
+});
+
+export const upsertSeatBinding = mutation({
+  args: {
+    mxid: v.string(),
+    tenant_id: v.string(),
+    seat_id: v.string(),
+    role: v.union(v.literal("owner"), v.literal("admin"), v.literal("member")),
+    status: v.optional(v.union(v.literal("active"), v.literal("suspended"))),
+  },
+  handler: async (ctx, args) => {
+    if (!args.mxid.trim()) throw new Error("mxid required");
+    if (!args.tenant_id.trim()) throw new Error("tenant_id required");
+    if (!args.seat_id.trim()) throw new Error("seat_id required");
+    // Core E1 invariant: reserved identities are server-minted only — never a binding target.
+    if (isReservedIdentity(args.seat_id)) {
+      throw new Error(
+        `cannot bind a human to a reserved identity "${args.seat_id}" — ` +
+          `reserved ids are server-minted only`,
+      );
+    }
+
+    const doc = {
+      mxid: args.mxid,
+      tenant_id: args.tenant_id,
+      seat_id: args.seat_id,
+      role: args.role,
+      status: args.status ?? ("active" as const),
+      updatedAt: Date.now(),
+    };
+
+    // Keyed by mxid — one binding per human. Second write updates, never duplicates.
+    const existing = await ctx.db
+      .query("seat_bindings")
+      .withIndex("by_mxid", (q) => q.eq("mxid", args.mxid))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+      return { status: "updated" as const, bindingId: existing._id };
+    }
+    const bindingId = await ctx.db.insert("seat_bindings", doc);
+    return { status: "created" as const, bindingId };
+  },
+});

--- a/convex/lib/enums.ts
+++ b/convex/lib/enums.ts
@@ -98,6 +98,13 @@ export const ADMIN_NEOP_ID = "_admin";
 // write paths so they remain explicit (and survive the Phase-B undefined⇒DENY flip).
 export const SYSTEM_NEOP_ID = "_system";
 
+// A reserved identity is SERVER-MINTED ONLY — never a valid channel-derived requester
+// and never a valid binding target (edge-auth #1/#3). Any `_`-prefixed id is reserved
+// (covers _admin/_system + future elevated ids). Mirrors acp/edge_auth.is_reserved_identity.
+export function isReservedIdentity(id: string): boolean {
+  return typeof id === "string" && id.trim().startsWith("_");
+}
+
 // ───── Convex document size guard ─────
 
 // Convex enforces a 1MB document limit. Leave headroom for metadata.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -365,6 +365,23 @@ export default defineSchema({
     .index("by_palace", ["palaceId"])
     .index("by_palace_neop", ["palaceId", "neopId"]),
 
+  // ── EDGE-AUTH: human ↔ seat bindings (#1/#3, E1) ─────────────
+  //
+  // The ONLY source of requester identity. resolveBinding(mxid) → (tenant, seat, role).
+  // NEVER writable from a channel path (deliberately NOT registered as an /mcp tool —
+  // the http dispatch can't reach it); provisioned per tenant. Write-time validation
+  // (upsertSeatBinding) REJECTS a reserved seat_id — a human is never bound to _admin/_system.
+  seat_bindings: defineTable({
+    mxid: v.string(),                      // Matrix user id (credential-verified by the AS)
+    tenant_id: v.string(),                 // = palace/tenant; from the AS namespace, never the body
+    seat_id: v.string(),                   // bound NEop seat (neopId) — never a reserved id
+    role: v.union(v.literal("owner"), v.literal("admin"), v.literal("member")),
+    status: v.union(v.literal("active"), v.literal("suspended")),
+    updatedAt: v.number(),
+  })
+    .index("by_mxid", ["mxid"])
+    .index("by_tenant", ["tenant_id"]),
+
   // ── INGESTION LOG ────────────────────────────────────────────
 
   ingestion_log: defineTable({

--- a/tests/edge_binding.test.ts
+++ b/tests/edge_binding.test.ts
@@ -1,0 +1,55 @@
+// Edge-auth E1 — seat_bindings store (#1/#3). Offline via convex-test.
+// The binding is the ONLY source of requester identity; write-time validation must reject
+// binding a human to a reserved (server-minted) identity.
+import { describe, expect, test } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../convex/schema.js";
+import { api } from "../convex/_generated/api.js";
+
+describe("Edge-auth E1 — seat_bindings store", () => {
+  test("resolveBinding miss returns null", async () => {
+    const t = convexTest(schema);
+    expect(await t.query(api.access.bindings.resolveBinding, { mxid: "@nobody:x" })).toBeNull();
+  });
+
+  test("upsert then resolve returns the binding", async () => {
+    const t = convexTest(schema);
+    const r = await t.mutation(api.access.bindings.upsertSeatBinding, {
+      mxid: "@alice:neuraledge.org", tenant_id: "neuraledge", seat_id: "aria", role: "member",
+    });
+    expect(r.status).toBe("created");
+    const b = await t.query(api.access.bindings.resolveBinding, { mxid: "@alice:neuraledge.org" });
+    expect(b!.seat_id).toBe("aria");
+    expect(b!.tenant_id).toBe("neuraledge");
+    expect(b!.status).toBe("active");
+  });
+
+  test("upsert is keyed by mxid — second write updates, never duplicates", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.access.bindings.upsertSeatBinding, {
+      mxid: "@a:x", tenant_id: "t", seat_id: "aria", role: "member",
+    });
+    const r2 = await t.mutation(api.access.bindings.upsertSeatBinding, {
+      mxid: "@a:x", tenant_id: "t", seat_id: "recon", role: "admin",
+    });
+    expect(r2.status).toBe("updated");
+    const all = await t.run(async (ctx: any) =>
+      ctx.db.query("seat_bindings").withIndex("by_mxid", (q: any) => q.eq("mxid", "@a:x")).collect());
+    expect(all.length).toBe(1);
+    expect(all[0]!.seat_id).toBe("recon");
+  });
+
+  test("write REJECTS binding a human to a reserved identity (server-minted only)", async () => {
+    const t = convexTest(schema);
+    for (const seat of ["_admin", "_system", "_x"]) {
+      await expect(
+        t.mutation(api.access.bindings.upsertSeatBinding, {
+          mxid: "@e:x", tenant_id: "t", seat_id: seat, role: "member",
+        }),
+      ).rejects.toThrow(/reserved/i);
+    }
+    // …and the store stays empty (nothing was written).
+    const any = await t.query(api.access.bindings.resolveBinding, { mxid: "@e:x" });
+    expect(any).toBeNull();
+  });
+});


### PR DESCRIPTION
The Convex half of edge-auth — where NEURAL-ops PR #8's `resolve_binding` seam points live.

- `seat_bindings { mxid, tenant_id, seat_id, role, status }` + `by_mxid`/`by_tenant`.
- `resolveBinding(mxid)` → binding|null (the edge calls this after the AS verifies the mxid).
- `upsertSeatBinding` — **provisioning-only, deliberately NOT an /mcp tool** (channels can't write a binding). Write-time validation **rejects a reserved seat_id** (no human → `_admin`/`_system`/`_*`), keyed by mxid (update, never duplicate).
- `isReservedIdentity` in enums (mirrors `acp/edge_auth.is_reserved_identity`).

`vitest 89 pass | 1 skip` (+4). **Codegen note:** tsc shows 7 stale-`_generated` errors (`api.access.bindings` is a new module not in committed codegen — same class as the twins/`getDrawer` noise); runtime resolves dynamically (vitest green) and `convex deploy` clears them. CI = vitest.

Live wiring (resolver → this store, + Synapse AS) is gated — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)