### PR TITLE
feat(acl): #12 — unify denied_at_layer into audit_events + Day-90 measurement

### DIFF
--- a/convex/access/mutations.ts
+++ b/convex/access/mutations.ts
@@ -20,6 +20,7 @@ export const logAuditEvent = mutation({
     resultCount: v.optional(v.number()),
     queryHash: v.optional(v.string()),
     extra: v.optional(v.string()),
+    deniedAtLayer: v.optional(v.string()),   // #12: layer tag when status=denied
   },
   handler: async (ctx, args) => {
     try {
@@ -38,10 +39,41 @@ export const logAuditEvent = mutation({
         resultCount: args.resultCount,
         queryHash: args.queryHash,
         extra: args.extra,
+        denied_at_layer: args.deniedAtLayer as Doc<"audit_events">["denied_at_layer"],
       });
     } catch (e) {
       // Swallow audit failures — they cannot break the calling op.
       console.error("audit write failed", e);
     }
+  },
+});
+
+// #12 — the unified-sink receiver for denials that happen OUTSIDE the Convex dispatch:
+// the edge resolver (denied_at_layer=edge) and the NEOS broker (=broker) push their refusals
+// here so all enforcement layers land in ONE audit_events sink (which nc-audit/S0.5 exports to
+// ClickHouse for the Day-90 measurement). convex_sot denials are tagged inline by the dispatch.
+export const recordExternalDenial = mutation({
+  args: {
+    palaceId: v.id("palaces"),
+    deniedAtLayer: v.union(v.literal("edge"), v.literal("broker"), v.literal("falkordb")),
+    neopId: v.optional(v.string()),   // declared/claimed seat or mxid; "unknown" if none
+    op: v.optional(v.string()),
+    reason: v.string(),
+    extra: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const who = args.neopId ?? "unknown";
+    await ctx.db.insert("audit_events", {
+      palaceId: args.palaceId,
+      op: (args.op ?? "search") as Doc<"audit_events">["op"],
+      neopId: who,
+      effectiveNeopId: who,
+      status: "denied",
+      latencyMs: 0,
+      timestamp: Date.now(),
+      denied_at_layer: args.deniedAtLayer,
+      extra: args.extra ?? JSON.stringify({ reason: args.reason }),
+    });
+    return { status: "recorded" as const };
   },
 });

--- a/convex/access/queries.ts
+++ b/convex/access/queries.ts
@@ -75,3 +75,34 @@ export const auditEventsForNeop = query({
       .take(limit ?? 50);
   },
 });
+
+// #12 — Day-90 measurement instrument. Counts DENIED ops per enforcement layer over a window,
+// so "isolation holds" is an audited fact: each layer's catch-rate is visible, and a layer
+// dropping to zero while attempts exist (or any untagged denial) is investigable. Denials are
+// the defense WORKING (a breach would be a cross-seat *success*, which the ACL prevents); this
+// surfaces the catches. Uses by_palace_status so it scans only denial rows (exceptional, bounded);
+// `capped` is honest about the take limit rather than silently truncating.
+export const denialsByLayer = query({
+  args: { palaceId: v.id("palaces"), sinceMs: v.optional(v.number()) },
+  handler: async (ctx, { palaceId, sinceMs }) => {
+    const CAP = 20000;
+    const denials = await ctx.db
+      .query("audit_events")
+      .withIndex("by_palace_status", (q) =>
+        q.eq("palaceId", palaceId).eq("status", "denied"),
+      )
+      .take(CAP);
+    const since = sinceMs ?? 0;
+    const byLayer: Record<string, number> = {
+      edge: 0, broker: 0, convex_sot: 0, falkordb: 0, untagged: 0,
+    };
+    let total = 0;
+    for (const d of denials) {
+      if (d.timestamp < since) continue;
+      total++;
+      const layer = d.denied_at_layer ?? "untagged";
+      byLayer[layer] = (byLayer[layer] ?? 0) + 1;
+    }
+    return { byLayer, total, windowFrom: since, capped: denials.length >= CAP };
+  },
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -135,6 +135,8 @@ http.route({
           status: isDenied ? "denied" : "error",
           latencyMs,
           extra: JSON.stringify({ tool, error: msg.slice(0, 200) }),
+          // #12: a denial AT the Convex dispatch/SoT is attributed to convex_sot.
+          deniedAtLayer: isDenied ? "convex_sot" : undefined,
         });
       } catch (auditErr) { console.error("[audit] write failed:", auditErr); }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -127,6 +127,16 @@ const auditStatus = v.union(
   v.literal("denied"),
 );
 
+// Which enforcement layer denied an op (#12). Unifies the denial signal across the stack so
+// the Day-90 "isolation holds" bar is measurable: edge-auth → "edge", NEOS broker → "broker",
+// Convex SoT dispatch/mutations → "convex_sot", FalkorDB bridge → "falkordb".
+const deniedAtLayer = v.union(
+  v.literal("edge"),
+  v.literal("broker"),
+  v.literal("convex_sot"),
+  v.literal("falkordb"),
+);
+
 const ingestionStatus = v.union(
   v.literal("pending"),
   v.literal("extracted"),
@@ -421,6 +431,7 @@ export default defineSchema({
     resultCount: v.optional(v.number()),
     queryHash: v.optional(v.string()),
     extra: v.optional(v.string()),         // JSON blob
+    denied_at_layer: v.optional(deniedAtLayer),   // #12: which layer denied (when status=denied)
   })
     .index("by_palace", ["palaceId"])
     .index("by_palace_time", ["palaceId", "timestamp"])

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -635,3 +635,55 @@ describe("Gate D — graph seat isolation (DEFERRED)", () => {
     // Requires a live/stubbed FalkorDB; tracked with Gate D, not offline-gradeable here.
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// #12 — denied_at_layer unified into audit_events (the Day-90 measurement sink).
+// A SoT dispatch denial self-tags convex_sot; edge/broker denials push in via
+// recordExternalDenial; denialsByLayer is the instrument that counts them.
+// ─────────────────────────────────────────────────────────────────
+
+describe("#12 — denied_at_layer unified audit + measurement", () => {
+  test("a SoT /mcp denial is tagged convex_sot and counted by denialsByLayer", async () => {
+    const { t, palaceId, roomB } = await setupSeatPalace();
+    const { status } = await call(t, "palace_add_closet",
+      { roomId: roomB, content: "x", category: "decision" }, "seat_a", palaceId);
+    expect(status).toBe(403);
+
+    const counts = await t.query(api.access.queries.denialsByLayer, { palaceId });
+    expect(counts.byLayer.convex_sot).toBeGreaterThanOrEqual(1);
+    expect(counts.total).toBeGreaterThanOrEqual(1);
+
+    // The raw audit row carries the layer tag.
+    const rows = await t.run(async (ctx: any) =>
+      ctx.db.query("audit_events").withIndex("by_palace_status",
+        (q: any) => q.eq("palaceId", palaceId).eq("status", "denied")).collect());
+    expect(rows.some((r: any) => r.denied_at_layer === "convex_sot")).toBe(true);
+  });
+
+  test("recordExternalDenial unifies edge + broker denials into the same sink", async () => {
+    const { t, palaceId } = await setupSeatPalace();
+    await t.mutation(api.access.mutations.recordExternalDenial, {
+      palaceId, deniedAtLayer: "edge", neopId: "@evil:x", reason: "reserved_identity_claimed_from_channel",
+    });
+    await t.mutation(api.access.mutations.recordExternalDenial, {
+      palaceId, deniedAtLayer: "broker", neopId: "unknown", reason: "blank_identity",
+    });
+    const counts = await t.query(api.access.queries.denialsByLayer, { palaceId });
+    expect(counts.byLayer.edge).toBe(1);
+    expect(counts.byLayer.broker).toBe(1);
+    expect(counts.total).toBe(2);
+  });
+
+  test("denialsByLayer respects the sinceMs window", async () => {
+    const { t, palaceId } = await setupSeatPalace();
+    await t.mutation(api.access.mutations.recordExternalDenial, {
+      palaceId, deniedAtLayer: "edge", reason: "x",
+    });
+    const future = await t.query(api.access.queries.denialsByLayer, {
+      palaceId, sinceMs: Date.now() + 60_000,
+    });
+    expect(future.total).toBe(0);
+    const all = await t.query(api.access.queries.denialsByLayer, { palaceId });
+    expect(all.total).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
Closes gap #12 — the SoT logged `status="denied"` with **no layer tag**, so "zero isolation violations in 30d" was unmeasurable. Now every enforcement layer lands in one sink with attribution.

- `audit_events.denied_at_layer` (`edge|broker|convex_sot|falkordb`).
- Dispatch self-tags SoT denials `convex_sot`; `logAuditEvent` threads it.
- **`recordExternalDenial`** — the unified-sink receiver so **edge-auth** (`=edge`) and the **broker** (`=broker`) push refusals into the **same** `audit_events`. (Edge/broker→Convex call is live-wiring; the receiver + tagging are built+tested.)
- **`denialsByLayer(palaceId, sinceMs?)`** — the Day-90 instrument: counts denials per layer over a window (scans only denial rows; `capped` flag, no silent truncation). Denials are the defense *working*; this surfaces each layer's catch-rate.

Pairs with #4 (erasure events already write to `audit_events`) and gives **nc-audit/S0.5** a single layer-tagged sink to export to ClickHouse.

`vitest 92 pass | 1 skip` (+3). No new tsc errors (the 7 `bindings` stale-codegen are E1's, cleared by `convex deploy`; CI = vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)