### PR TITLE
fix(acl): #6 — surface embedding health (close silent-retrieval-degradation)

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -278,15 +278,19 @@ async function dispatch(
 
     // ── NAVIGATION ────────────────────────────────────────
     case "palace_status": {
-      const [l0, l1, stats] = await Promise.all([
+      const [l0, l1, stats, embedding] = await Promise.all([
         ctx.runQuery(api.serving.l0l1.getL0, { palaceId }),
         ctx.runQuery(api.serving.l0l1.getL1, { palaceId }),
         ctx.runQuery(api.palace.queries.getStats, { palaceId }),
+        // #6: embedding health at session start — a blocked/missing embedder degrades
+        // retrieval silently, so surface it loudly here rather than via empty search.
+        ctx.runQuery(api.palace.queries.embeddingHealth, { palaceId }),
       ]);
       return {
         l0: l0 ?? "Palace identity not generated. Run seed:palace first.",
         l1: l1 ?? "Wing index not generated.",
         stats,
+        embedding,
         protocol: PALACE_PROTOCOL,
         neop: { id: neopId, scope: perms.scopeWing ? `${perms.scopeWing}/${perms.scopeRoom ?? "*"}` : "unrestricted" },
       };

--- a/convex/lib/qwen.ts
+++ b/convex/lib/qwen.ts
@@ -21,6 +21,16 @@ export const EMBEDDING_DIMENSIONS = 1024;
 export const EMBEDDING_API_URL =
   `https://bedrock-runtime.${BEDROCK_REGION}.amazonaws.com/model/${encodeURIComponent(BEDROCK_MODEL_ID)}/invoke`;
 
+// #6 — embedding-provider visibility. The embedder credential must live in the CONVEX
+// DEPLOYMENT env (not the runtime container); when absent, embedOne throws → closets land
+// embeddingStatus="failed" → retrieval silently degrades. These let a health query SURFACE
+// that — single source of truth for the provider name + env key.
+export const EMBEDDER_PROVIDER = "bedrock-titan-v2";
+export const EMBEDDER_ENV_KEY = "AWS_BEARER_TOKEN_BEDROCK";
+export function embedderConfigured(): boolean {
+  return !!(process.env[EMBEDDER_ENV_KEY] || "").trim();
+}
+
 // Titan v2 accepts up to 8192 tokens (~32K chars). Keep a safe margin.
 const MAX_CONTENT_CHARS = 30_000;
 

--- a/convex/palace/queries.ts
+++ b/convex/palace/queries.ts
@@ -7,6 +7,7 @@
 import { query, internalQuery } from "../_generated/server.js";
 import { v } from "convex/values";
 import type { Id, Doc } from "../_generated/dataModel.js";
+import { embedderConfigured, EMBEDDER_PROVIDER, EMBEDDER_ENV_KEY } from "../lib/qwen.js";
 
 // ─── PALACES ─────────────────────────────────────────────────
 
@@ -502,5 +503,39 @@ export const getStats = query({
       drawers: { total: drawers.length, valid: validDrawers.length },
       tunnels: tunnels.length,
     };
+  },
+});
+
+// #6 — embedding health. Retrieval is the product, but a missing/blocked embedder fails
+// SILENTLY (embedOne throws → embeddingStatus="failed" → vector search returns nothing, no
+// loud error). This surfaces it: per-status counts + whether the embedder credential is set
+// in the Convex deployment env + a `degraded` verdict, so palace_status (called at session
+// start) shows it instead of an operator discovering empty search results.
+export const embeddingHealth = query({
+  args: { palaceId: v.id("palaces") },
+  handler: async (ctx, { palaceId }) => {
+    const counts = { pending: 0, generated: 0, failed: 0 };
+    for (const status of ["pending", "generated", "failed"] as const) {
+      const rows = await ctx.db
+        .query("closets")
+        .withIndex("by_embedding_status", (q) =>
+          q.eq("palaceId", palaceId).eq("embeddingStatus", status),
+        )
+        .collect();
+      counts[status] = rows.filter((c) => !c.retracted).length;
+    }
+    const total = counts.pending + counts.generated + counts.failed;
+    const configured = embedderConfigured();
+    // Degraded iff: no embedder credential, OR closets exist but none embedded, OR any failed.
+    const degraded = !configured || (total > 0 && counts.generated === 0) || counts.failed > 0;
+    const reason = !configured
+      ? `embedder credential absent — set ${EMBEDDER_ENV_KEY} in the Convex deployment env ` +
+        `(provider=${EMBEDDER_PROVIDER}); until then every write fails to embed and retrieval is blind`
+      : counts.failed > 0
+        ? `${counts.failed} closet(s) failed to embed — vector retrieval is degraded`
+        : total > 0 && counts.generated === 0
+          ? `${total} closet(s) but none embedded yet — retrieval will return nothing`
+          : "ok";
+    return { provider: EMBEDDER_PROVIDER, configured, counts, total, degraded, reason };
   },
 });

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -547,6 +547,49 @@ describe("Gate B-2 — owner-namespaced room resolution", () => {
 // or isn't auditable is a compliance hole.
 // ─────────────────────────────────────────────────────────────────
 
+describe("#6 — embedding health (silent-degradation visibility)", () => {
+  test("flags an unconfigured embedder (retrieval would be blind)", async () => {
+    const saved = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    try {
+      const t = convexTest(schema);
+      const { palaceId } = await makePalace(t);
+      const h = await t.query(api.palace.queries.embeddingHealth, { palaceId });
+      expect(h.configured).toBe(false);
+      expect(h.degraded).toBe(true);
+      expect(h.reason).toMatch(/credential absent/i);
+    } finally {
+      if (saved !== undefined) process.env.AWS_BEARER_TOKEN_BEDROCK = saved;
+    }
+  });
+
+  test("surfaces failed embeddings even when the embedder is configured", async () => {
+    const saved = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "test-token";
+    try {
+      const t = convexTest(schema);
+      const { palaceId, roomId } = await makePalace(t);
+      const a = await t.mutation(api.palace.mutations.createCloset,
+        baseClosetArgs(palaceId, roomId, { sourceExternalId: "a" }) as any);
+      const b = await t.mutation(api.palace.mutations.createCloset,
+        baseClosetArgs(palaceId, roomId, { sourceExternalId: "b", content: "other" }) as any);
+      await t.run(async (ctx: any) => {
+        await ctx.db.patch(a.closetId, { embeddingStatus: "generated" });
+        await ctx.db.patch(b.closetId, { embeddingStatus: "failed" });
+      });
+      const h = await t.query(api.palace.queries.embeddingHealth, { palaceId });
+      expect(h.configured).toBe(true);
+      expect(h.counts.generated).toBe(1);
+      expect(h.counts.failed).toBe(1);
+      expect(h.degraded).toBe(true);   // failed > 0
+      expect(h.reason).toMatch(/failed to embed/i);
+    } finally {
+      if (saved === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      else process.env.AWS_BEARER_TOKEN_BEDROCK = saved;
+    }
+  });
+});
+
 describe("#4 — retract erasure cascade + audit", () => {
   test("retract redacts + invalidates the closet's drawers and writes an audited erasure event", async () => {
     const t = convexTest(schema);


### PR DESCRIPTION
Closes gap #6. The live embedder is **Bedrock Titan** (`AWS_BEARER_TOKEN_BEDROCK` in the **Convex deployment** env) and **Bedrock is account-blocked** — so embeddings fail silently (`embeddingStatus=failed`) and vector search goes blind with no error.

- `embeddingHealth(palaceId)` — per-status counts + `configured` (credential present) + `degraded` verdict + reason.
- `palace_status` (session start) now returns `embedding`, so the blindness is loud.
- `qwen.ts`: `embedderConfigured`/`EMBEDDER_PROVIDER`/`EMBEDDER_ENV_KEY` (single source of truth).

`vitest 94 | 1 skip` (+2). **Provider decision flagged (not code):** a working 1024-d embedder must be chosen + keyed in the Convex deployment env (Bedrock blocked; Qwen/Voyage/Gemini all dead per the header). This makes the state visible; it doesn't pick the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)