### PR TITLE
feat(acl): S0.3 Phase B — fail-closed SoT flip (undefined => DENY)

### DIFF
--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -408,7 +408,13 @@ export function assertActorCanWriteRoom(
   actorNeopId: string | undefined,
   room: RoomScope,
 ): void {
-  if (actorNeopId === undefined) return;        // Phase A: still trusted (flips to DENY in Phase B)
+  // Phase B (FAIL-CLOSED): omission no longer means trust. A server-minted caller MUST pass an
+  // explicit actor — `_system` for trusted internal paths, `_admin` for admin, or a seat. This is
+  // safe because #2 made the dispatch thread `_admin` (never undefined) and the actor_coverage guard
+  // proves no source call site omits the actor; the flip only denies a direct call that omits it.
+  if (actorNeopId === undefined) {
+    throw new AccessDenied("(unspecified)", "SoT fail-closed: a guarded write requires an explicit actorNeopId");
+  }
   if (actorNeopId === SYSTEM_NEOP_ID) return;   // trusted internal actor (elevated)
   if (actorNeopId === ADMIN_NEOP_ID) return;    // admin bypass
   if (!(room.ownerNeopId && room.ownerNeopId === actorNeopId)) {
@@ -423,7 +429,10 @@ export function assertActorCanReadRoom(
   actorNeopId: string | undefined,
   room: RoomScope,
 ): void {
-  if (actorNeopId === undefined) return;        // Phase A: still trusted (flips to DENY in Phase B)
+  // Phase B (FAIL-CLOSED) — see assertActorCanWriteRoom. Omission no longer means trust.
+  if (actorNeopId === undefined) {
+    throw new AccessDenied("(unspecified)", "SoT fail-closed: a guarded read requires an explicit actorNeopId");
+  }
   if (actorNeopId === SYSTEM_NEOP_ID) return;   // trusted internal actor (elevated)
   if (actorNeopId === ADMIN_NEOP_ID) return;    // admin bypass
   const own = !!room.ownerNeopId && room.ownerNeopId === actorNeopId;

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -398,10 +398,10 @@ async function seedClosetDrawer(t: any, palaceId: string, roomId: string) {
   const r = await t.mutation(api.palace.mutations.createCloset, {
     palaceId, roomId, content: "owned by B", category: "fact",
     sourceType: "manual", sourceAdapter: "test", sourceExternalId: "b-seed",
-    authorType: "system", authorId: "test", confidence: 0.9,
+    authorType: "system", authorId: "test", confidence: 0.9, actorNeopId: "_system",
   });
   await t.mutation(api.palace.mutations.createDrawer, {
-    closetId: r.closetId, palaceId, fact: "B fact", validFrom: 1, confidence: 0.9,
+    closetId: r.closetId, palaceId, fact: "B fact", validFrom: 1, confidence: 0.9, actorNeopId: "_system",
   });
   const drawers = await t.query(api.palace.queries.listDrawers, { closetId: r.closetId });
   return { closetId: r.closetId as string, drawerId: drawers[0]._id as string };
@@ -567,10 +567,11 @@ describe("Gate A+ — L1 SoT independent enforcement (direct mutation calls)", (
     ).rejects.toThrow(/SoT write-scope/i);
   });
 
-  test("createCloset DIRECT with NO actorNeopId → allowed (trusted internal caller preserved)", async () => {
+  test("createCloset DIRECT with NO actorNeopId → DENIED (Phase B fail-closed)", async () => {
     const { t, palaceId, roomB } = await setupSeatPalace();
-    const r = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomB) as any);
-    expect(r.status).toBe("created"); // crons/ingestion still write anywhere
+    await expect(
+      t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomB) as any),
+    ).rejects.toThrow(/fail-closed/i); // omission no longer means trust; callers pass _system
   });
 
   test("createCloset DIRECT with actorNeopId=_admin → allowed (admin bypass)", async () => {

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -498,10 +498,10 @@ describe("Gate B-2 — owner-namespaced room resolution", () => {
     const { palaceId } = await makePalace(t);
 
     const a1 = await t.mutation(api.palace.mutations.getOrCreateRoom, {
-      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_a",
+      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_a", actorNeopId: "_system",
     });
     const b1 = await t.mutation(api.palace.mutations.getOrCreateRoom, {
-      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_b",
+      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_b", actorNeopId: "_system",
     });
     expect(a1).not.toEqual(b1);
 
@@ -512,7 +512,7 @@ describe("Gate B-2 — owner-namespaced room resolution", () => {
 
     // Idempotent WITHIN an owner namespace.
     const a2 = await t.mutation(api.palace.mutations.getOrCreateRoom, {
-      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_a",
+      palaceId, wingName: "platform", roomName: "topic", ownerNeopId: "seat_a", actorNeopId: "_system",
     });
     expect(a2).toEqual(a1);
   });
@@ -523,16 +523,16 @@ describe("Gate B-2 — owner-namespaced room resolution", () => {
 
     // Company namespace (admin / bulk-ingest path: no owner) — stable on repeat.
     const company = await t.mutation(api.palace.mutations.getOrCreateRoom, {
-      palaceId, wingName: "platform", roomName: "shared-topic",
+      palaceId, wingName: "platform", roomName: "shared-topic", actorNeopId: "_system",
     });
     const companyAgain = await t.mutation(api.palace.mutations.getOrCreateRoom, {
-      palaceId, wingName: "platform", roomName: "shared-topic",
+      palaceId, wingName: "platform", roomName: "shared-topic", actorNeopId: "_system",
     });
     expect(companyAgain).toEqual(company);
 
     // A scoped seat gets its OWN room, not the company one.
     const seat = await t.mutation(api.palace.mutations.getOrCreateRoom, {
-      palaceId, wingName: "platform", roomName: "shared-topic", ownerNeopId: "seat_a",
+      palaceId, wingName: "platform", roomName: "shared-topic", ownerNeopId: "seat_a", actorNeopId: "_system",
     });
     expect(seat).not.toEqual(company);
 
@@ -598,7 +598,7 @@ describe("#4 — retract erasure cascade + audit", () => {
     const { palaceId, roomId } = await makePalace(t);
     const r = await t.mutation(api.palace.mutations.createCloset, baseClosetArgs(palaceId, roomId) as any);
     await t.mutation(api.palace.mutations.createDrawer, {
-      closetId: r.closetId, palaceId, fact: "sensitive PII fact", validFrom: 1, confidence: 0.9,
+      closetId: r.closetId, palaceId, fact: "sensitive PII fact", validFrom: 1, confidence: 0.9, actorNeopId: "_system",
     });
 
     const res = await t.mutation(api.palace.mutations.retractCloset, {

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -185,7 +185,7 @@ describe("Phase 1 invariants", () => {
       t.mutation(api.palace.mutations.retractCloset, {
         closetId: r.closetId,
         reason: "test",
-        retractedBy: "_admin",
+        retractedBy: "_admin", actorNeopId: "_system",
       }),
     ).rejects.toThrow(/legal hold/i);
   });
@@ -209,7 +209,7 @@ describe("Phase 1 invariants", () => {
     await t.mutation(api.palace.mutations.retractCloset, {
       closetId: r.closetId,
       reason: "GDPR request",
-      retractedBy: "_admin",
+      retractedBy: "_admin", actorNeopId: "_system",
     });
 
     const closet = await t.query(api.palace.queries.getCloset, { closetId: r.closetId });
@@ -253,6 +253,7 @@ describe("Phase 1 invariants", () => {
         toRoomId: roomBId,
         relationship: "depends_on",
         strength: 0.8,
+        actorNeopId: "_system",
       }),
     ).rejects.toThrow(/cross-palace/i);
   });
@@ -403,7 +404,7 @@ describe("Phase 1 invariants", () => {
     expect(visible.length).toBe(2);
 
     await t.mutation(api.palace.mutations.retractCloset, {
-      closetId: r1.closetId, reason: "test", retractedBy: "_admin",
+      closetId: r1.closetId, reason: "test", retractedBy: "_admin", actorNeopId: "_system",
     });
 
     visible = await t.query(api.palace.queries.listClosets, { roomId });
@@ -601,7 +602,7 @@ describe("#4 — retract erasure cascade + audit", () => {
     });
 
     const res = await t.mutation(api.palace.mutations.retractCloset, {
-      closetId: r.closetId, reason: "GDPR erase", retractedBy: "_admin",
+      closetId: r.closetId, reason: "GDPR erase", retractedBy: "_admin", actorNeopId: "_system",
     });
     expect(res.drawersRedacted).toBe(1);
 
@@ -626,7 +627,7 @@ describe("#4 — retract erasure cascade + audit", () => {
     const { palaceId, roomId } = await makePalace(t);
     const r = await t.mutation(api.palace.mutations.createCloset, baseClosetArgs(palaceId, roomId) as any);
     const res = await t.mutation(api.palace.mutations.retractCloset, {
-      closetId: r.closetId, reason: "x", retractedBy: "_admin",
+      closetId: r.closetId, reason: "x", retractedBy: "_admin", actorNeopId: "_system",
     });
     expect(res.drawersRedacted).toBe(0);
     const audits = await t.run(async (ctx: any) =>

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -69,6 +69,7 @@ const baseClosetArgs = (palaceId: string, roomId: string, overrides: Record<stri
   authorType: "adapter",
   authorId: "claude-export",
   confidence: 0.8,
+  actorNeopId: "_system",   // Phase B: tests act as a trusted internal seeder
   ...overrides,
 });
 


### PR DESCRIPTION
Final identity-spine piece. Flips the L1 SoT guards (`assertActorCanWrite/ReadRoom`) from Phase-A fail-open (`undefined => trusted`) to **fail-closed** (`undefined => DENY`). Preconditions met: completeness guard green (#2) + full spine live-validated (self-host, 4/4 + 7/7).

**Inert in production:** the dispatch threads `_admin` (#2), ingestion/scripts thread `_system`, and the completeness guard proves no source call site omits the actor — so only a direct mutation call with NO actor now denies (the deepest independence). Test fixtures that seed as trusted callers migrated to `actorNeopId:"_system"`. `vitest 94 pass | 1 skip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)