### PR TITLE
fix(#6): palace_search degrades gracefully when the embedder is unavailable

### DIFF
--- a/convex/serving/search.ts
+++ b/convex/serving/search.ts
@@ -147,10 +147,25 @@ export async function coreSearch(
   );
   const clientId = palaceDoc?.clientId ?? "";
 
-  const [queryEmbedding, graphHits] = await Promise.all([
-    embedOne(trimmed),
-    clientId ? graphSearch(clientId, trimmed, 15) : Promise.resolve([]),
-  ]);
+  // #6: retrieval degrades GRACEFULLY when the embedder is unavailable (credential absent /
+  // provider blocked) — return the structured low-confidence shape instead of an uncaught 500.
+  // embeddingHealth surfaces the root cause. The graph is advisory, so its failure never blocks.
+  let queryEmbedding: number[];
+  try {
+    queryEmbedding = await embedOne(trimmed);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      results: [],
+      confidence: "low" as const,
+      reason: `retrieval_unavailable: embedder error (${msg.slice(0, 80)})`,
+      tokenEstimate: 0,
+      queryTimeMs: 0,
+    };
+  }
+  const graphHits = clientId
+    ? await graphSearch(clientId, trimmed, 15).catch(() => [])
+    : [];
 
   const graphBoostMap = buildGraphBoostMap(graphHits);
 


### PR DESCRIPTION
E2E (live broker) caught it: `palace_search` threw an uncaught HTTP 500 `AWS_BEARER_TOKEN_BEDROCK not set` when the blocked embedder couldn't embed the query — retrieval **crashed** instead of degrading. Now the query-embed failure returns the existing structured shape `{results:[], confidence:'low', reason:'retrieval_unavailable: embedder error (...)'}`; the advisory graph path is hardened (`.catch(()=>[])`). **Verified live:** `broker.retrieve` now returns `confidence=low, reason=retrieval_unavailable` (was a 500). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)