### PR TITLE
feat(P2/L2): FalkorDB-bridge tenant-scope enforcement + denied_at_layer=falkordb

### DIFF
--- a/services/bridge_identity.py
+++ b/services/bridge_identity.py
@@ -1,0 +1,53 @@
+"""FalkorDB-bridge L2 — tenant-scope enforcement + denied_at_layer=falkordb (P2).
+
+Closes the L2 gap: the shared `X-Palace-Key` authenticates the DISPATCHER but does NOT bind a
+caller to a TENANT — so a key-holder could pass another tenant's palace_id and reach its graph.
+This requires an `X-NEop-Identity` (tenant[/seat]) and refuses any request whose palace_id is not
+the identity's tenant, emitting a `denied_at_layer=falkordb` record (→ Convex recordExternalDenial;
+the live emit is the wiring step). TENANT-level only — graph SEAT-isolation stays deferred (Gate D).
+
+In this bridge `palace_id` IS the tenant key (PalaceRegistry maps tenant→graph_name), so the check
+is `identity_tenant == palace_id`. Pure + offline-gradeable; signing (HMAC/Ed25519 over the header)
+is production hardening layered on top of this decision.
+"""
+from __future__ import annotations
+from typing import Optional, Tuple
+
+DENIED_AT_LAYER = "falkordb"
+
+
+def parse_identity(header: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """`X-NEop-Identity` = '<tenant>:<seat>' (seat optional). Returns (tenant, seat) or (None, None)."""
+    if not isinstance(header, str) or not header.strip():
+        return None, None
+    parts = header.strip().split(":", 1)
+    tenant = parts[0].strip() or None
+    seat = parts[1].strip() if len(parts) > 1 and parts[1].strip() else None
+    return tenant, seat
+
+
+def _denial(palace_id, tenant, seat, reason) -> dict:
+    return {
+        "denied_at_layer": DENIED_AT_LAYER,
+        "reason": reason,
+        "palace_id": palace_id,
+        "claimed_tenant": tenant,
+        "seat": seat,
+    }
+
+
+def verify_tenant_scope(palace_id: str, identity_header: Optional[str], registry):
+    """Decide whether a graph op on `palace_id` is in the caller's tenant scope.
+
+    Returns (allowed: bool, denial: dict | None). The denial carries denied_at_layer=falkordb so
+    the audit's `falkordb` slot finally emits (today it is plumbed-but-silent in denialsByLayer).
+    """
+    tenant, seat = parse_identity(identity_header)
+    if registry.graph_for(palace_id) is None:
+        return False, _denial(palace_id, tenant, seat, "unknown_palace")
+    if tenant is None:
+        return False, _denial(palace_id, tenant, seat, "missing_neop_identity")
+    if tenant != palace_id:
+        # A valid dispatcher key, but a tenant that does not own the requested graph.
+        return False, _denial(palace_id, tenant, seat, "cross_tenant")
+    return True, None

--- a/services/test_bridge_identity.py
+++ b/services/test_bridge_identity.py
@@ -1,0 +1,54 @@
+"""P2 — FalkorDB-bridge L2 tenant-scope enforcement. Offline, stdlib only (no pytest/FalkorDB).
+Run: python3 services/test_bridge_identity.py"""
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from bridge_identity import verify_tenant_scope, parse_identity, DENIED_AT_LAYER  # noqa: E402
+
+
+class FakeRegistry:
+    def __init__(self, ids): self.ids = set(ids)
+    def graph_for(self, pid): return ("graph_" + pid) if pid in self.ids else None
+
+
+REG = FakeRegistry(["neuraledge", "zoo_media"])
+
+
+def test_parse_identity():
+    assert parse_identity("neuraledge:aria") == ("neuraledge", "aria")
+    assert parse_identity("neuraledge") == ("neuraledge", None)
+    assert parse_identity("") == (None, None)
+    assert parse_identity(None) == (None, None)
+    print("PASS test_parse_identity")
+
+
+def test_own_tenant_allowed():
+    ok, denial = verify_tenant_scope("neuraledge", "neuraledge:aria", REG)
+    assert ok and denial is None
+    print("PASS test_own_tenant_allowed")
+
+
+def test_cross_tenant_denied_emits_falkordb():
+    ok, d = verify_tenant_scope("zoo_media", "neuraledge:aria", REG)
+    assert not ok
+    assert d["denied_at_layer"] == DENIED_AT_LAYER == "falkordb"
+    assert d["reason"] == "cross_tenant" and d["claimed_tenant"] == "neuraledge"
+    print("PASS test_cross_tenant_denied_emits_falkordb")
+
+
+def test_missing_identity_denied():
+    ok, d = verify_tenant_scope("neuraledge", None, REG)
+    assert not ok and d["reason"] == "missing_neop_identity" and d["denied_at_layer"] == "falkordb"
+    print("PASS test_missing_identity_denied")
+
+
+def test_unknown_palace_denied():
+    ok, d = verify_tenant_scope("acme", "acme:x", REG)
+    assert not ok and d["reason"] == "unknown_palace" and d["denied_at_layer"] == "falkordb"
+    print("PASS test_unknown_palace_denied")
+
+
+if __name__ == "__main__":
+    for n, f in sorted(globals().items()):
+        if n.startswith("test_") and callable(f):
+            f()
+    print("ALL BRIDGE-IDENTITY TESTS PASS")


### PR DESCRIPTION
Closes the L2 gap: shared X-Palace-Key authenticates the dispatcher but doesn't bind a caller to a tenant. verify_tenant_scope refuses cross-tenant/missing-identity/unknown-palace and emits denied_at_layer=falkordb (the slot was plumbed-but-silent). Pure + offline (test_bridge_identity 5/5). Tenant-level; seat-isolation stays deferred (Gate D). Next: wire into bridge middleware behind cfg.identity_enabled (default off) + live recordExternalDenial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)