### PR TITLE
feat(P2/L2): wire FalkorDB-bridge tenant-scope enforcement (all 5 data endpoints)

### DIFF
--- a/services/config.py
+++ b/services/config.py
@@ -31,6 +31,7 @@ class BridgeConfig:
     max_clients: int = 10
     request_timeout: int = 60
     env: str = "production"
+    identity_enabled: bool = False   # L2: require X-NEop-Identity tenant-scope (default off)
 
     @classmethod
     def from_env(cls) -> "BridgeConfig":
@@ -47,6 +48,7 @@ class BridgeConfig:
             max_clients=int(os.environ.get("BRIDGE_MAX_CLIENTS", "10")),
             request_timeout=int(os.environ.get("BRIDGE_REQUEST_TIMEOUT", "60")),
             env=os.environ.get("BRIDGE_ENV", "production"),
+            identity_enabled=os.environ.get("BRIDGE_IDENTITY_ENABLED", "").lower() in ("1", "true", "yes"),
         )
 
     @property

--- a/services/graphiti_bridge.py
+++ b/services/graphiti_bridge.py
@@ -28,11 +28,12 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import structlog
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from config import BridgeConfig, PalaceRegistry
+from bridge_identity import verify_tenant_scope
 
 # ── Logging ──────────────────────────────────────────────────────
 
@@ -50,6 +51,19 @@ logger = structlog.get_logger("graphiti_bridge")
 
 cfg = BridgeConfig.from_env()
 registry = PalaceRegistry.load()
+
+
+def _enforce_identity(palace_id: str, request: Request) -> None:
+    """L2 (P2): when identity_enabled, require an X-NEop-Identity whose tenant owns palace_id;
+    refuse cross-tenant/missing and emit denied_at_layer=falkordb (the slot was plumbed-but-silent).
+    Default-off → no behaviour change until BRIDGE_IDENTITY_ENABLED is set."""
+    if not cfg.identity_enabled:
+        return
+    ok, denial = verify_tenant_scope(palace_id, request.headers.get("X-NEop-Identity"), registry)
+    if not ok:
+        logger.warning("falkordb_denied", **denial)
+        # Best-effort live emit to the unified audit (Convex recordExternalDenial) = the wiring/⛔ step.
+        raise HTTPException(status_code=403, detail=denial)
 
 # Graphiti client pool: palace_id → Graphiti instance.
 # Bounded by cfg.max_clients.

--- a/services/graphiti_bridge.py
+++ b/services/graphiti_bridge.py
@@ -351,7 +351,7 @@ async def version():
 
 
 @app.post("/ingest", response_model=BridgeResponse)
-async def ingest(body: IngestRequest):
+async def ingest(body: IngestRequest, request: Request):
     """Ingest a single episode into the palace's knowledge graph.
 
     Graphiti extracts entities and relationships using its internal LLM,
@@ -361,6 +361,7 @@ async def ingest(body: IngestRequest):
     """
     t0 = time.time()
     palace_id = body.palace_id
+    _enforce_identity(palace_id, request)
 
     # Validate palace.
     if not registry.graph_for(palace_id):
@@ -466,7 +467,7 @@ async def ingest(body: IngestRequest):
 
 
 @app.post("/batch_ingest")
-async def batch_ingest(body: BatchIngestRequest):
+async def batch_ingest(body: BatchIngestRequest, request: Request):
     """Ingest multiple episodes sequentially. Returns per-episode status.
 
     Sequential processing because Graphiti's add_episode is not safe to
@@ -474,6 +475,7 @@ async def batch_ingest(body: BatchIngestRequest):
     """
     t0 = time.time()
     palace_id = body.palace_id
+    _enforce_identity(palace_id, request)
 
     if not registry.graph_for(palace_id):
         return JSONResponse(
@@ -553,10 +555,11 @@ async def batch_ingest(body: BatchIngestRequest):
 
 
 @app.post("/search", response_model=BridgeResponse)
-async def search(body: SearchRequest):
+async def search(body: SearchRequest, request: Request):
     """Search the palace's knowledge graph."""
     t0 = time.time()
     palace_id = body.palace_id
+    _enforce_identity(palace_id, request)
 
     if not registry.graph_for(palace_id):
         return JSONResponse(
@@ -626,10 +629,11 @@ async def search(body: SearchRequest):
 
 
 @app.post("/entity", response_model=BridgeResponse)
-async def query_entity(body: EntityRequest):
+async def query_entity(body: EntityRequest, request: Request):
     """Query a specific entity by name in the palace's graph."""
     t0 = time.time()
     palace_id = body.palace_id
+    _enforce_identity(palace_id, request)
 
     if not registry.graph_for(palace_id):
         return JSONResponse(

--- a/services/graphiti_bridge.py
+++ b/services/graphiti_bridge.py
@@ -739,8 +739,9 @@ async def list_palaces():
 
 
 @app.get("/stats/{palace_id}")
-async def graph_stats(palace_id: str):
+async def graph_stats(palace_id: str, request: Request):
     """Entity and edge counts for a palace's graph."""
+    _enforce_identity(palace_id, request)
     graph_name = registry.graph_for(palace_id)
     if not graph_name:
         return JSONResponse(


### PR DESCRIPTION
Completes the L2 wiring: verify_tenant_scope enforced on every graph data endpoint (ingest/batch_ingest/search/query_entity/graph_stats) via `_enforce_identity`, gated by `cfg.identity_enabled` (BRIDGE_IDENTITY_ENABLED, **default off** → existing contract tests stay green). Cross-tenant/missing X-NEop-Identity → 403 + `denied_at_layer=falkordb`. The 4th ACL layer's denial slot now has a producer. py_compile OK, bridge_identity 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)