### PR TITLE
feat(P2): paused_runs — Convex durable store for AwaitingApproval (live-proven)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -37,6 +37,7 @@ import type * as maintenance_pruner from "../maintenance/pruner.js";
 import type * as maintenance_tunnels from "../maintenance/tunnels.js";
 import type * as migrations_runner from "../migrations/runner.js";
 import type * as palace_mutations from "../palace/mutations.js";
+import type * as palace_pausedRuns from "../palace/pausedRuns.js";
 import type * as palace_provision from "../palace/provision.js";
 import type * as palace_queries from "../palace/queries.js";
 import type * as palace_twins from "../palace/twins.js";
@@ -86,6 +87,7 @@ declare const fullApi: ApiFromModules<{
   "maintenance/tunnels": typeof maintenance_tunnels;
   "migrations/runner": typeof migrations_runner;
   "palace/mutations": typeof palace_mutations;
+  "palace/pausedRuns": typeof palace_pausedRuns;
   "palace/provision": typeof palace_provision;
   "palace/queries": typeof palace_queries;
   "palace/twins": typeof palace_twins;

--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -275,10 +275,12 @@ const TOOL_TO_OP: Record<string, string> = {
   palace_walk_tunnel: "recall",
   palace_stats: "recall",
   palace_get_twin: "recall",
+  palace_get_paused_run: "recall",
 
   // Write ops → remember
   palace_remember: "remember",
   palace_put_twin: "remember",
+  palace_save_paused_run: "remember",
   palace_add_closet: "remember",
   palace_add_drawer: "remember",
   palace_create_room: "remember",

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -373,6 +373,26 @@ async function dispatch(
         maturity: params.maturity as string,
       });
 
+    // ── PAUSED RUNS (AwaitingApproval durable pause; P2) ───────
+    // Same own-seat discipline as twins: neopId is server-overwritten, get→recall / save→remember
+    // already gated. A caller can only reach its OWN paused runs — no cross-seat read/write.
+    case "palace_get_paused_run":
+      return ctx.runQuery(api.palace.pausedRuns.getPausedRun, {
+        palaceId,
+        neopId,
+        runId: params.runId as string,
+      });
+
+    case "palace_save_paused_run":
+      // Blind upsert; runtime owns the snapshot shape (no server-side validation).
+      return ctx.runMutation(api.palace.pausedRuns.putPausedRun, {
+        palaceId,
+        neopId,
+        runId: params.runId as string,
+        state: params.state,
+        status: params.status as string | undefined,
+      });
+
     // ── STORAGE ───────────────────────────────────────────
     // palace_remember routes through the TRUSTED ingestion pipeline (ingestExchange →
     // getOrCreateRoom → createCloset), which bypasses the per-room write guards by design.

--- a/convex/palace/pausedRuns.ts
+++ b/convex/palace/pausedRuns.ts
@@ -1,0 +1,59 @@
+// Paused-run accessors — durable AwaitingApproval snapshots, ADDRESSED by (palaceId, neopId, runId).
+//
+// The runtime (NEOS core.py) owns the snapshot shape (to_state); the server is a BLIND store, exactly
+// like twins — no validation of `state`, latest-wins upsert by runId. The Decision Queue surfaces
+// pending pauses (by_palace_status); resume loads by runId and reconstructs the Pi-agent. Seat
+// isolation is enforced upstream: the /mcp handler overwrites neopId server-side and gates
+// get→recall / save→remember, so a caller can only reach its OWN paused runs (same discipline as twins).
+
+import { query, mutation } from "../_generated/server.js";
+import { v } from "convex/values";
+
+// palace_get_paused_run → { state: <object> | null, status?, updatedAt? }
+export const getPausedRun = query({
+  args: { palaceId: v.id("palaces"), neopId: v.string(), runId: v.string() },
+  handler: async (ctx, { palaceId, neopId, runId }) => {
+    const row = await ctx.db
+      .query("paused_runs")
+      .withIndex("by_palace_neop_run", (q) =>
+        q.eq("palaceId", palaceId).eq("neopId", neopId).eq("runId", runId),
+      )
+      .first();
+    if (!row) return { state: null };
+    return { state: row.state, status: row.status, updatedAt: row.updatedAt };
+  },
+});
+
+// palace_save_paused_run → { status, runId, upsert }. Blind upsert by (palaceId, neopId, runId).
+export const putPausedRun = mutation({
+  args: {
+    palaceId: v.id("palaces"),
+    neopId: v.string(),
+    runId: v.string(),
+    state: v.any(),
+    status: v.optional(v.string()),
+  },
+  handler: async (ctx, { palaceId, neopId, runId, state, status }) => {
+    const existing = await ctx.db
+      .query("paused_runs")
+      .withIndex("by_palace_neop_run", (q) =>
+        q.eq("palaceId", palaceId).eq("neopId", neopId).eq("runId", runId),
+      )
+      .first();
+    const now = Date.now();
+    const st = status ?? "pending";
+    if (existing) {
+      await ctx.db.patch(existing._id, { state, status: st, updatedAt: now });
+      return { status: "ok", runId, upsert: "update" };
+    }
+    await ctx.db.insert("paused_runs", {
+      palaceId,
+      neopId,
+      runId,
+      state,
+      status: st,
+      updatedAt: now,
+    });
+    return { status: "ok", runId, upsert: "insert" };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -343,6 +343,21 @@ export default defineSchema({
   })
     .index("by_palace_neop", ["palaceId", "neopId"]),
 
+  // ── PAUSED RUNS (AwaitingApproval durable pause; P2) ─────────
+  // One row per paused NEop run, addressed by (palaceId, neopId, runId). `state` is the runtime's
+  // to_state snapshot (runtime owns the shape; server is a blind store, like twins). The Decision
+  // Queue reads pending rows by tenant+status; resume loads by runId and reconstructs the Pi-agent.
+  paused_runs: defineTable({
+    palaceId: v.id("palaces"),
+    neopId: v.string(),                    // = seat that owns the paused run
+    runId: v.string(),                     // correlation key (Decision Queue ↔ resume)
+    state: v.any(),                        // serialized to_state snapshot (runtime-owned shape)
+    status: v.string(),                    // "pending" | "resolved"
+    updatedAt: v.number(),
+  })
+    .index("by_palace_neop_run", ["palaceId", "neopId", "runId"])
+    .index("by_palace_status", ["palaceId", "status"]),
+
   // ── VECTOR EMBEDDINGS (versioned by model) ───────────────────
 
   closet_embeddings: defineTable({


### PR DESCRIPTION
## What
The **server counterpart** to the runtime `ConvexSnapshotStore` seam (NEURAL-ops #18). Makes the `AwaitingApproval` pause **durable** — survives the process for the hours a human approval can take. Mirrors the `twins` pattern exactly (per-`(palaceId,neopId)` blind store; the runtime owns the snapshot shape).

- **schema** — `paused_runs` table, indexed `by_palace_neop_run` (resume by `runId`) + `by_palace_status` (Decision Queue: pending approvals per tenant).
- **`convex/palace/pausedRuns.ts`** — `getPausedRun` (query) + `putPausedRun` (blind upsert).
- **`/mcp` dispatch** — `palace_get_paused_run` / `palace_save_paused_run`, same own-seat discipline as twins (`neopId` server-overwritten, no cross-seat reach).
- **`enforce.ts` `TOOL_TO_OP`** — `get→recall`, `save→remember` (gated, not default-allow).

## Live-proven (self-host backend)
- `save` → `{upsert: insert}` then re-save → `{upsert: update}`; `get` round-trips the **exact** snapshot (`pause_scope`, `paused_task_id`, `status: pending`).
- `convex deploy`: schema validation clean, no indexes deleted.
- **vitest 94 pass | 1 skip** — no regression.

Pairs with the runtime `ConvexSnapshotStore` (calls `palace_save_paused_run`/`palace_get_paused_run`). Remaining gov-flip piece: bridge→Convex `recordExternalDenial` emit, then the live policy flip (yours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)