### PR TITLE
feat(P2): bridge→Convex external-denial emit — L2 denials reach denialsByLayer (live-proven)

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -160,6 +160,53 @@ http.route({
   }),
 });
 
+// ─── External denial sink (P2: out-of-Convex layers → unified audit) ──────────
+// Least-privilege ingress so layers that live OUTSIDE Convex (the FalkorDB bridge L2, edge) can
+// record a denial into the unified audit (denied_at_layer) — feeding denialsByLayer so the Day-90
+// instrument counts EVERY layer, not just the in-Convex ones. Authenticated by a SHARED service
+// secret (PALACE_BRIDGE_API_KEY), NOT the admin key. Default-OFF: if the secret is unset the route
+// is disabled (503) so it can never be an open audit-spam vector. Best-effort by contract — the
+// caller (the bridge) treats any failure as non-fatal; the client already got its 403.
+http.route({
+  path: "/external-denial",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const secret = process.env.PALACE_BRIDGE_API_KEY;
+    if (!secret) return jsonResponse({ error: "denial_sink_disabled" }, 503);
+    if (request.headers.get("X-Palace-Key") !== secret)
+      return jsonResponse({ error: "unauthorized" }, 401);
+    let body: {
+      palaceId: string;
+      deniedAtLayer: "edge" | "broker" | "falkordb";
+      neopId?: string;
+      op?: string;
+      reason: string;
+      extra?: string;
+    };
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse({ error: "invalid_json" }, 400);
+    }
+    if (!body?.palaceId || !body?.deniedAtLayer || !body?.reason)
+      return jsonResponse({ error: "missing palaceId/deniedAtLayer/reason" }, 400);
+    try {
+      const res = await ctx.runMutation(api.access.mutations.recordExternalDenial, {
+        palaceId: body.palaceId as Id<"palaces">,
+        deniedAtLayer: body.deniedAtLayer,
+        neopId: body.neopId,
+        op: body.op,
+        reason: body.reason,
+        extra: body.extra,
+      });
+      return jsonResponse(res);
+    } catch (e) {
+      // A bad palaceId etc. must not 500 a best-effort emit — surface a typed 400.
+      return jsonResponse({ error: "record_failed", detail: String(e) }, 400);
+    }
+  }),
+});
+
 // ─── Seat-isolation helpers (Gate B) ────────────────────────────
 // Resolve the owning room for an addressed entity, then the caller applies the
 // pure scope guard (assertNeopScope / assertNeopReadScope). Used by non-admin

--- a/services/config.py
+++ b/services/config.py
@@ -32,6 +32,7 @@ class BridgeConfig:
     request_timeout: int = 60
     env: str = "production"
     identity_enabled: bool = False   # L2: require X-NEop-Identity tenant-scope (default off)
+    denial_sink_url: str = ""        # P2: Convex base URL for the external-denial emit ("" => off)
 
     @classmethod
     def from_env(cls) -> "BridgeConfig":
@@ -49,6 +50,7 @@ class BridgeConfig:
             request_timeout=int(os.environ.get("BRIDGE_REQUEST_TIMEOUT", "60")),
             env=os.environ.get("BRIDGE_ENV", "production"),
             identity_enabled=os.environ.get("BRIDGE_IDENTITY_ENABLED", "").lower() in ("1", "true", "yes"),
+            denial_sink_url=os.environ.get("CONVEX_DENIAL_SINK_URL", "").rstrip("/"),
         )
 
     @property

--- a/services/graphiti_bridge.py
+++ b/services/graphiti_bridge.py
@@ -19,10 +19,12 @@ Design notes (from ultrathink analysis):
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import sys
 import time
+import urllib.request
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Optional
@@ -62,8 +64,33 @@ def _enforce_identity(palace_id: str, request: Request) -> None:
     ok, denial = verify_tenant_scope(palace_id, request.headers.get("X-NEop-Identity"), registry)
     if not ok:
         logger.warning("falkordb_denied", **denial)
-        # Best-effort live emit to the unified audit (Convex recordExternalDenial) = the wiring/⛔ step.
+        _emit_external_denial(palace_id, denial)   # best-effort unified-audit emit (P2)
         raise HTTPException(status_code=403, detail=denial)
+
+
+def _emit_external_denial(palace_id: str, denial: dict) -> None:
+    """Best-effort: record an L2 denial into the unified Convex audit (denied_at_layer=falkordb) so
+    `denialsByLayer` counts the bridge layer, not just the in-Convex ones. Credential-gated
+    (cfg.denial_sink_url) + offline-safe: ANY failure is logged and swallowed — the client already
+    got its 403, so the emit must never block, delay, or raise. POSTs to the least-privilege
+    /external-denial sink with the shared bridge key; the sink is itself default-off server-side."""
+    if not cfg.denial_sink_url:
+        return
+    try:
+        body = json.dumps({
+            "palaceId": denial.get("palace_id", palace_id),
+            "deniedAtLayer": denial.get("denied_at_layer", "falkordb"),
+            "neopId": denial.get("claimed_seat") or denial.get("claimed_tenant"),
+            "reason": denial.get("reason", "tenant_scope_denied"),
+            "extra": json.dumps(denial, sort_keys=True),
+        }).encode()
+        req = urllib.request.Request(
+            f"{cfg.denial_sink_url}/external-denial", data=body,
+            headers={"Content-Type": "application/json", "X-Palace-Key": cfg.api_key},
+        )
+        urllib.request.urlopen(req, timeout=3).close()  # noqa: S310 (trusted internal sink)
+    except Exception as e:  # best-effort: the audit emit must never break the deny path
+        logger.warning("external_denial_emit_failed", error=str(e), palace_id=palace_id)
 
 # Graphiti client pool: palace_id → Graphiti instance.
 # Bounded by cfg.max_clients.

--- a/services/test_external_denial_emit.py
+++ b/services/test_external_denial_emit.py
@@ -1,0 +1,69 @@
+"""P2 — bridge external-denial emit (piece #3). Offline, no live backend required.
+Run: python3 services/test_external_denial_emit.py
+
+Proves the bridge's best-effort emit contract: no-op when the sink is unset, posts the right payload
+to /external-denial with the shared key, and SWALLOWS any failure (the client already got its 403, so
+the audit emit must never block or raise). The Convex sink + the full denialsByLayer chain are proven
+live separately (curl + denialsByLayer falkordb count)."""
+import json
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import graphiti_bridge as gb  # noqa: E402
+
+
+def test_noop_when_sink_unset():
+    gb.cfg.denial_sink_url = ""
+    gb._emit_external_denial("pX", {"reason": "x"})   # must not raise, no network
+    print("PASS test_noop_when_sink_unset")
+
+
+def test_posts_expected_payload():
+    captured = {}
+
+    class _Resp:
+        def close(self):
+            pass
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["key"] = req.get_header("X-palace-key")
+        captured["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    gb.cfg.denial_sink_url = "http://sink.example"
+    gb.cfg.api_key = "secret"
+    orig = gb.urllib.request.urlopen
+    gb.urllib.request.urlopen = fake_urlopen
+    try:
+        gb._emit_external_denial("pX", {
+            "denied_at_layer": "falkordb", "reason": "cross_tenant",
+            "palace_id": "pX", "claimed_tenant": "acme", "claimed_seat": "bob"})
+    finally:
+        gb.urllib.request.urlopen = orig
+    assert captured["url"] == "http://sink.example/external-denial", captured["url"]
+    assert captured["key"] == "secret"
+    b = captured["body"]
+    assert b["deniedAtLayer"] == "falkordb"
+    assert b["palaceId"] == "pX"
+    assert b["neopId"] == "bob"            # claimed_seat preferred over tenant
+    assert b["reason"] == "cross_tenant"
+    assert "claimed_tenant" in b["extra"]  # full denial preserved for forensics
+    print("PASS test_posts_expected_payload")
+
+
+def test_swallows_errors():
+    # An unreachable sink must be logged-and-swallowed, never raised (best-effort).
+    gb.cfg.denial_sink_url = "http://127.0.0.1:1"
+    gb.cfg.api_key = "k"
+    gb._emit_external_denial("pX", {"denied_at_layer": "falkordb", "reason": "x"})
+    gb.cfg.denial_sink_url = ""            # reset module state
+    print("PASS test_swallows_errors")
+
+
+if __name__ == "__main__":
+    for n, f in sorted(globals().items()):
+        if n.startswith("test_") and callable(f):
+            f()
+    print("ALL EXTERNAL-DENIAL EMIT TESTS PASS")


### PR DESCRIPTION
## What
The **third and final gov-flip seam piece**. The FalkorDB-bridge L2 denial now lands in the **unified audit**, so the Day-90 `denialsByLayer` instrument counts the bridge layer — not just the in-Convex ones. Closes the `wiring/⛔` placeholder that was sitting in `_enforce_identity`.

- **`convex/http.ts`** — a least-privilege `POST /external-denial` `httpAction` for layers that live *outside* Convex (the bridge, edge) to record a denial. Authenticated by a **shared service secret** (`PALACE_BRIDGE_API_KEY`), **not** the admin key; **default-OFF** (503) if the secret is unset, so it can never be an open audit-spam vector. Calls the existing `recordExternalDenial` mutation.
- **`services/graphiti_bridge.py`** — `_emit_external_denial`: **best-effort + offline-safe**. POSTs the denial, credential-gated (`cfg.denial_sink_url`), and **swallows all errors** — the client already got its 403, so the emit must never block, delay, or raise.
- **`services/config.py`** — `denial_sink_url` (`CONVEX_DENIAL_SINK_URL`; `""` ⇒ off).

## Live-proven (self-host, full chain)
The **actual** `_emit_external_denial` Python path → `/external-denial` (401 on no/wrong key; `{status:recorded}` on valid) → `recordExternalDenial` → `audit_events` → **`denialsByLayer` `falkordb` count incremented (1 → 2)**.
- Unit **3/3** (no-op when off · correct payload+key · swallows errors).
- Regression: bridge-identity **5/5**, bridge-contract **13/13**.

## Result — the gov-flip seam is complete
All three pieces landed: runtime `ConvexSnapshotStore` (NEURAL-ops #18), Convex `paused_runs` (#19), and this. What remains is **yours**: the minimal approval policy + flipping `identity_enabled` / `CONVEX_DENIAL_SINK_URL` on for the dogfood tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)