### PR TITLE
feat(P2): twin = identity, not memory (B2 carve-out, live-proven)

### DIFF
--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -113,6 +113,23 @@ export async function resolvePermissions(
   };
 }
 
+// B2 (docs/decisions/twin-keying.md) — identity WITHOUT memory capabilities. A validly-named seat HAS an
+// identity (its neopId) even with no neop_permissions row; it just holds no runtime ops. Used for twin
+// ops (identity self-access): the seat reaches its OWN twin without a perms row, while memory/content
+// tools still deny via enforceRuntimeOp (empty runtimeOps). Never grants an op; never elevates to admin.
+// The exact-own-twin bound lives in getTwin/putTwin (`q.eq("neopId", neopId)`, server-derived neopId).
+export function identityOnlyPerms(neopId: string): ResolvedPermissions {
+  return {
+    neopId,
+    effectiveNeopId: neopId,
+    runtimeOps: [],
+    contentAccess: {},
+    scopeWing: null,
+    scopeRoom: null,
+    isAdmin: false,
+  };
+}
+
 // ─── Runtime op check ───────────────────────────────────────────
 
 export function hasRuntimeOp(perms: ResolvedPermissions, op: string): boolean {
@@ -274,12 +291,10 @@ const TOOL_TO_OP: Record<string, string> = {
   palace_get_room: "recall",
   palace_walk_tunnel: "recall",
   palace_stats: "recall",
-  palace_get_twin: "recall",
   palace_get_paused_run: "recall",
 
   // Write ops → remember
   palace_remember: "remember",
-  palace_put_twin: "remember",
   palace_save_paused_run: "remember",
   palace_add_closet: "remember",
   palace_add_drawer: "remember",
@@ -294,6 +309,14 @@ const TOOL_TO_OP: Record<string, string> = {
 
   // Meta
   palace_export: "recall",
+
+  // NOTE: palace_get_twin / palace_put_twin are DELIBERATELY ABSENT (B2, docs/decisions/twin-keying.md).
+  // The twin is IDENTITY, not memory — reading/writing your own self-model is self-access by *being* that
+  // identity, categorically different from recall/remember (memory of stored facts). So twin ops are NOT
+  // gated by a memory op. A twin op can only ever touch the twin at its own request neopId (getTwin/putTwin
+  // key by an exact `q.eq("neopId", neopId)` — no prefix, no wildcard), and neopId is the server-derived
+  // requester (edge-auth E1–E5, unforgeable). Cross-user isolation rests on that exact server-derived key,
+  // NOT on the recall/remember gate (which only checked "does this seat do memory", never twin ownership).
 };
 
 export function runtimeOpForTool(tool: string): string | null {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -19,6 +19,7 @@ import { ADMIN_NEOP_ID } from "./lib/enums.js";
 import {
   type ResolvedPermissions,
   resolvePermissions,
+  identityOnlyPerms,
   enforceRuntimeOp,
   enforceScope,
   enforceWrite,
@@ -83,11 +84,18 @@ http.route({
 
     try {
       // ── Phase 7: Access control gate ────────────────────
-      // Resolve permissions via a mutation (has db access).
-      const perms: ResolvedPermissions = await ctx.runQuery(
-        internal.access.queries.resolvePermsQuery,
-        { palaceId: pid, neopId },
-      );
+      // B2 (docs/decisions/twin-keying.md): the twin is IDENTITY, not memory. Own-twin access needs a
+      // valid identity, NOT a neop_permissions row — so twin ops resolve to identity-only perms and skip
+      // the unknown-neopId throw in resolvePermissions. They are ungated (no runtime op); the exact
+      // own-twin bound is getTwin/putTwin's `q.eq("neopId", neopId)` over the server-derived neopId.
+      // Every other tool resolves perms normally (throws on unknown seat) and is op-gated as before.
+      const isTwinTool = tool === "palace_get_twin" || tool === "palace_put_twin";
+      const perms: ResolvedPermissions = isTwinTool
+        ? identityOnlyPerms(neopId)
+        : await ctx.runQuery(internal.access.queries.resolvePermsQuery, {
+            palaceId: pid,
+            neopId,
+          });
 
       // Check runtime op.
       const requiredOp = runtimeOpForTool(tool);

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -346,6 +346,16 @@ describe("Tool to runtime op mapping", () => {
   test("unknown tool returns null", () => {
     expect(runtimeOpForTool("nonexistent_tool")).toBeNull();
   });
+
+  // B2 (docs/decisions/twin-keying.md): twin is IDENTITY, not memory — own-twin access is NOT gated by
+  // a memory op. getTwin/putTwin key by an exact server-derived neopId; isolation rests on that, not on
+  // recall/remember. paused_run ops (memory-like) stay gated, proving the carve-out is twin-specific.
+  test("twin ops are NOT memory-gated (B2 identity self-access)", () => {
+    expect(runtimeOpForTool("palace_get_twin")).toBeNull();
+    expect(runtimeOpForTool("palace_put_twin")).toBeNull();
+    expect(runtimeOpForTool("palace_get_paused_run")).toBe("recall");
+    expect(runtimeOpForTool("palace_save_paused_run")).toBe("remember");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
Per `docs/decisions/twin-keying.md`. The twin is **identity** — reading/writing your own self-model is self-access by *being* that identity, categorically different from `recall`/`remember` (memory of stored facts). Gating own-twin access behind a memory permission was a category error. **B2 fixes the category.**

- `enforce.ts`: `palace_get_twin`/`palace_put_twin` **removed from `TOOL_TO_OP`** (no longer memory-gated) + `identityOnlyPerms(neopId)` — a valid identity with **zero** runtime ops.
- `http.ts`: twin tools resolve to `identityOnlyPerms` and **skip `resolvePermissions`' unknown-neopId throw**; every other tool resolves perms normally (still throws on unknown) and is op-gated as before.

## The safety bar (the carve-out's single bound)
"Own twin" = an **exact** match on the **server-derived** neopId — `getTwin`/`putTwin` key by `q.eq("neopId", neopId)`, neopId minted by edge-auth (E1–E5, unforgeable). **No prefix, no wildcard, nothing looser.** Adds **no new trust assumption** — it rests on the same edge-auth invariant the keying already rests on, and removes a memory check that never provided cross-user isolation anyway.

## Why B2 (not A/B1)
Deletes the `binding ⇒ perms` footgun (no `neop_permissions` row needed to reach your own twin → no silent-deny class), and avoids B1's over-grant (B1 would hand every human seat general `recall`+`remember` just to unlock twin access, conflating identity with memory).

## Live-proven (self-host)
A **permless** seat PUTs+GETs its **own** twin (`upsert:insert` + readback `{identity:"Eve"}`), while the **same seat is still DENIED a memory op** (`palace_search` → "no permissions found") — proving the carve-out is twin-specific. vitest **95 pass | 1 skip** (added the B2 mapping assertion).

## Pairs with
The `core.py` `twin_owner = requester or seat` keying (NEURAL-ops, next PR). Together: per-user twin, accessed by identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)