### PR TITLE
feat(P3): Decision Queue read + resume-resolve (live-proven)

### DIFF
--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -296,6 +296,7 @@ const TOOL_TO_OP: Record<string, string> = {
   // Write ops → remember
   palace_remember: "remember",
   palace_save_paused_run: "remember",
+  palace_resolve_paused_run: "remember",
   palace_add_closet: "remember",
   palace_add_drawer: "remember",
   palace_create_room: "remember",

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -448,6 +448,15 @@ async function dispatch(
         status: params.status as string | undefined,
       });
 
+    case "palace_resolve_paused_run":
+      // Flip a pause pending→resolved|denied on resume, so the Decision Queue stops showing it.
+      return ctx.runMutation(api.palace.pausedRuns.markPausedRun, {
+        palaceId,
+        neopId,
+        runId: params.runId as string,
+        status: (params.status as string) ?? "resolved",
+      });
+
     // ── STORAGE ───────────────────────────────────────────
     // palace_remember routes through the TRUSTED ingestion pipeline (ingestExchange →
     // getOrCreateRoom → createCloset), which bypasses the per-room write guards by design.

--- a/convex/palace/pausedRuns.ts
+++ b/convex/palace/pausedRuns.ts
@@ -57,3 +57,52 @@ export const putPausedRun = mutation({
     return { status: "ok", runId, upsert: "insert" };
   },
 });
+
+// palace_list_paused_runs → the DECISION QUEUE read: the tenant's PENDING pauses (AwaitingApproval),
+// newest first. Uses by_palace_status so it scans only pending rows (bounded). Surfaces the gated action
+// + scope so an operator can decide; the full snapshot stays server-side (loaded by runId on resume).
+export const pendingPausedRuns = query({
+  args: { palaceId: v.id("palaces"), limit: v.optional(v.number()) },
+  handler: async (ctx, { palaceId, limit }) => {
+    const rows = await ctx.db
+      .query("paused_runs")
+      .withIndex("by_palace_status", (q) =>
+        q.eq("palaceId", palaceId).eq("status", "pending"),
+      )
+      .order("desc")
+      .take(limit ?? 100);
+    return {
+      pending: rows.map((r) => ({
+        runId: r.runId,
+        neopId: r.neopId,
+        pauseScope: (r.state as { pause_scope?: string })?.pause_scope ?? null,
+        action: (r.state as { action?: unknown })?.action ?? null,
+        updatedAt: r.updatedAt,
+      })),
+      count: rows.length,
+    };
+  },
+});
+
+// palace_resolve_paused_run → flip a pause pending→resolved (or →denied) once the run has resumed to a
+// terminal. Patches ONLY status (the snapshot is unchanged), so the Decision Queue stops showing it. Keyed
+// by the exact (palaceId, neopId, runId); a no-op if the row is gone.
+export const markPausedRun = mutation({
+  args: {
+    palaceId: v.id("palaces"),
+    neopId: v.string(),
+    runId: v.string(),
+    status: v.string(), // "resolved" | "denied"
+  },
+  handler: async (ctx, { palaceId, neopId, runId, status }) => {
+    const row = await ctx.db
+      .query("paused_runs")
+      .withIndex("by_palace_neop_run", (q) =>
+        q.eq("palaceId", palaceId).eq("neopId", neopId).eq("runId", runId),
+      )
+      .first();
+    if (!row) return { status: "noop", runId };
+    await ctx.db.patch(row._id, { status, updatedAt: Date.now() });
+    return { status: "ok", runId };
+  },
+});

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -355,6 +355,7 @@ describe("Tool to runtime op mapping", () => {
     expect(runtimeOpForTool("palace_put_twin")).toBeNull();
     expect(runtimeOpForTool("palace_get_paused_run")).toBe("recall");
     expect(runtimeOpForTool("palace_save_paused_run")).toBe("remember");
+    expect(runtimeOpForTool("palace_resolve_paused_run")).toBe("remember");
   });
 });
 


### PR DESCRIPTION
## What
Closes a real completeness gap: `paused_runs` had a `by_palace_status` index built **for** the Decision Queue, but **no query read it**, and **nothing flipped a pause `pending→resolved` on resume**. So the human-in-the-loop surface that AwaitingApproval exists to serve had no way to list pending pauses, and would have shown already-granted ones forever.

- `pausedRuns.ts`: **`pendingPausedRuns(palaceId)`** query — the Decision Queue read (pending only, newest first, surfaces the gated action + scope); **`markPausedRun`** mutation — patches status only (snapshot unchanged).
- `http.ts`: `palace_resolve_paused_run` `/mcp` tool (the runtime broker calls it on resume).
- `enforce.ts`: `palace_resolve_paused_run → remember`.

## Live-proven (self-host, operator path)
save pending → `pendingPausedRuns` **count 1** (showing the gated `bash` action) → `markPausedRun` resolved → **count 0**. vitest **95 pass | 1 skip**.

Pairs with the runtime resolve-on-resume (NEURAL-ops PR). Found by the "verify the child, not the node" completeness sweep — the index existed, the purpose it was built for did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)