### PR TITLE
fix(bridge): COPY bridge_identity.py into the image

### DIFF
--- a/services/Dockerfile
+++ b/services/Dockerfile
@@ -11,6 +11,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY config.py .
+COPY bridge_identity.py .
 COPY graphiti_bridge.py .
 COPY graph_writer.py .
 


### PR DESCRIPTION
The Graphiti bridge container crash-looped on AWS with:

```
ModuleNotFoundError: No module named 'bridge_identity'
  File "/app/graphiti_bridge.py", line 38, in <module>
    from bridge_identity import verify_tenant_scope
```

`services/Dockerfile` copied `config.py`, `graphiti_bridge.py`, `graph_writer.py` but omitted
`bridge_identity.py` (the L2 tenant-scope verifier that `graphiti_bridge.py` imports). One-line fix:
add `COPY bridge_identity.py .`

Found during the NEOS dogfood spine AWS deploy; with this fix the bridge ECS service starts cleanly
and all three spine services are stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)