### PR TITLE
feat(embedder): Bedrock Titan via PrivateLink (selector + Gemini parked + Voyage passage)

### DIFF
--- a/convex/ingestion/ingest.ts
+++ b/convex/ingestion/ingest.ts
@@ -20,7 +20,7 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel.js";
 import { scanForPII } from "./pii.js";
 import { routeToWing, routeToRoom, classifyCategory, scoreConfidence } from "./route.js";
-import { embedOne, EMBEDDING_MODEL } from "../lib/qwen.js";
+import { embedOne, EMBEDDING_MODEL } from "../lib/embedder.js";
 import { callGeminiLlm } from "../lib/geminiLlm.js";
 import { CATEGORIES, SYSTEM_NEOP_ID } from "../lib/enums.js";
 import { EXTRACTION_SYSTEM_PROMPT, parseExtractionResponse, type ExtractionItem } from "./extract.js";

--- a/convex/lib/embedder.ts
+++ b/convex/lib/embedder.ts
@@ -1,0 +1,17 @@
+// Active embedding provider — the SINGLE place the embedder is chosen.
+//
+// Everything that embeds (ingestion/embed, ingestion/ingest, serving/search, palace/queries health)
+// imports from HERE, never from a concrete provider lib. Switching providers is this one line.
+//
+//   active:   ./gemini.js     (gemini-embedding-001, 1024-d, L2-normalized) — the unblocked path.
+//   parked:   ./qwen.js       (Bedrock Titan v2, 1024-d) — blocked account-wide; re-point here if Bedrock opens.
+//   PLANNED:  ./voyage.js     (NOT YET) — the stated target embedder. Forward-dependency, named not hidden:
+//             Gemini is correct *for now* (no Voyage key on hand). Moving to Voyage = add lib/voyage.js +
+//             change the line below. The runtime is embedding-agnostic so the *switch* is cheap, but a
+//             *re-embed* is required if Voyage's dimension/space differs from gemini-embedding-001's 1024-d.
+//             Tracked as the "embedder provider" passage in docs/production-readiness.md.
+//
+// Provider libs MUST export the same surface: EMBEDDING_MODEL · EMBEDDING_DIMENSIONS · EMBEDDER_PROVIDER ·
+// EMBEDDER_ENV_KEY · embedderConfigured · truncateForEmbedding · embedOne · embedBatchTexts · EmbedInputType.
+
+export * from "./gemini.js";

--- a/convex/lib/embedder.ts
+++ b/convex/lib/embedder.ts
@@ -3,15 +3,18 @@
 // Everything that embeds (ingestion/embed, ingestion/ingest, serving/search, palace/queries health)
 // imports from HERE, never from a concrete provider lib. Switching providers is this one line.
 //
-//   active:   ./gemini.js     (gemini-embedding-001, 1024-d, L2-normalized) — the unblocked path.
-//   parked:   ./qwen.js       (Bedrock Titan v2, 1024-d) — blocked account-wide; re-point here if Bedrock opens.
+//   active:   ./qwen.js       (Bedrock Titan v2, 1024-d, server-normalized) — reaches Bedrock via the
+//             bedrock-runtime PrivateLink VPC endpoint, so it needs NO internet/NAT. The correct embedder
+//             for the no-NAT spine (verified: Titan embeddings ARE available on this account; the stale
+//             "Bedrock blocked" note was disproven by a live invoke-model test). Auth = AWS_BEARER_TOKEN_BEDROCK.
+//   parked:   ./gemini.js     (gemini-embedding-001, 1024-d, client-L2) — correct code, but Google's API is
+//             external internet with NO VPC endpoint → needs NAT. One-line switch here IF a NAT/EIP lands.
 //   PLANNED:  ./voyage.js     (NOT YET) — the stated target embedder. Forward-dependency, named not hidden:
-//             Gemini is correct *for now* (no Voyage key on hand). Moving to Voyage = add lib/voyage.js +
-//             change the line below. The runtime is embedding-agnostic so the *switch* is cheap, but a
-//             *re-embed* is required if Voyage's dimension/space differs from gemini-embedding-001's 1024-d.
+//             Bedrock Titan is correct *for now* (no Voyage key on hand; Bedrock is internet-free in-VPC).
+//             Moving to Voyage = add lib/voyage.js + change the line below + a re-embed IF dims/space differ.
 //             Tracked as the "embedder provider" passage in docs/production-readiness.md.
 //
 // Provider libs MUST export the same surface: EMBEDDING_MODEL · EMBEDDING_DIMENSIONS · EMBEDDER_PROVIDER ·
 // EMBEDDER_ENV_KEY · embedderConfigured · truncateForEmbedding · embedOne · embedBatchTexts · EmbedInputType.
 
-export * from "./gemini.js";
+export * from "./qwen.js";

--- a/convex/lib/gemini.ts
+++ b/convex/lib/gemini.ts
@@ -1,0 +1,148 @@
+// Gemini text embeddings — embedding provider (the unblocked path; Bedrock Titan is account-blocked).
+//
+// Model:    gemini-embedding-001  (Google Generative Language API, v1beta)
+// Dims:     1024  — matches the schema `by_embedding` vector index EXACTLY (no re-index).
+//           gemini-embedding-001 supports outputDimensionality (Matryoshka); we request 1024.
+// Norm:     CLIENT-SIDE L2. Gemini only auto-normalizes at the full 3072-d output; at a truncated
+//           dimension it returns UN-normalized vectors (measured L2≈0.61 @1024). Cosine/dot retrieval
+//           needs unit vectors, so we normalize here — the silent-garbage failure class if skipped.
+// Context:  ~2048 input tokens for this model (smaller than Titan's 8K) → tighter truncation.
+// Task:     uses taskType (RETRIEVAL_DOCUMENT / RETRIEVAL_QUERY) — the `inputType` arg that was a
+//           no-op for Titan is a real asymmetric-retrieval quality lever for Gemini.
+//
+// Provider switch lives in lib/embedder.ts (the single active-provider choice). FORWARD-DEPENDENCY:
+// the stated target embedder is Voyage; Gemini is correct *for now* (Voyage key not on hand). Moving to
+// Voyage later is a re-embed IF the dimension/space differs — see the ledger "embedder provider" passage.
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+export const EMBEDDING_MODEL = "gemini-embedding-001";
+export const EMBEDDING_DIMENSIONS = 1024;
+export const EMBEDDING_API_URL =
+  `${GEMINI_API_BASE}/models/${EMBEDDING_MODEL}:embedContent`;
+
+// Single source of truth for the provider name + env key (surfaced by the embeddingHealth query).
+// The credential must live in the CONVEX deployment env (`convex env set GEMINI_API_KEY ...`), NOT the
+// runtime container — embeddings compute server-side here; when absent, embedOne throws → closets land
+// embeddingStatus="failed" → retrieval silently degrades, which the health query exposes.
+export const EMBEDDER_PROVIDER = "gemini-embedding-001";
+export const EMBEDDER_ENV_KEY = "GEMINI_API_KEY";
+export function embedderConfigured(): boolean {
+  return !!(process.env[EMBEDDER_ENV_KEY] || "").trim();
+}
+
+// gemini-embedding-001 accepts ~2048 tokens; keep a safe char margin (~4 chars/token).
+const MAX_CONTENT_CHARS = 8_000;
+
+export type EmbedInputType = "query" | "document";
+
+export function truncateForEmbedding(text: string): string {
+  if (text.length <= MAX_CONTENT_CHARS) return text;
+  return text.slice(0, MAX_CONTENT_CHARS);
+}
+
+function taskTypeFor(inputType: EmbedInputType): string {
+  return inputType === "query" ? "RETRIEVAL_QUERY" : "RETRIEVAL_DOCUMENT";
+}
+
+// L2-normalize to unit length (required: Gemini does not normalize truncated-dim output).
+function l2normalize(vec: number[]): number[] {
+  let sumSq = 0;
+  for (const x of vec) sumSq += x * x;
+  const norm = Math.sqrt(sumSq);
+  if (norm === 0) return vec;
+  return vec.map((x) => x / norm);
+}
+
+function apiKey(): string {
+  const key = (process.env[EMBEDDER_ENV_KEY] || "").trim();
+  if (!key) throw new Error(`${EMBEDDER_ENV_KEY} not set in the Convex deployment env`);
+  return key;
+}
+
+export async function embedOne(
+  text: string,
+  inputType: EmbedInputType = "document",
+): Promise<number[]> {
+  const truncated = truncateForEmbedding(text);
+  if (!truncated.trim()) {
+    return new Array(EMBEDDING_DIMENSIONS).fill(0);
+  }
+
+  const response = await fetch(`${EMBEDDING_API_URL}?key=${apiKey()}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: `models/${EMBEDDING_MODEL}`,
+      content: { parts: [{ text: truncated }] },
+      taskType: taskTypeFor(inputType),
+      outputDimensionality: EMBEDDING_DIMENSIONS,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Gemini embed error ${response.status}: ${body.slice(0, 300)}`);
+  }
+
+  const data = (await response.json()) as { embedding?: { values?: number[] } };
+  const values = data.embedding?.values;
+  if (!values || values.length !== EMBEDDING_DIMENSIONS) {
+    throw new Error(
+      `Gemini returned ${values?.length ?? 0}-dim, expected ${EMBEDDING_DIMENSIONS}`,
+    );
+  }
+  return l2normalize(values);
+}
+
+export async function embedBatchTexts(
+  texts: string[],
+  inputType: EmbedInputType = "document",
+): Promise<{ embeddings: number[][]; count: number }> {
+  if (texts.length === 0) return { embeddings: [], count: 0 };
+
+  // batchEmbedContents caps requests per call; chunk conservatively.
+  const BATCH = 100;
+  const results: number[][] = new Array(texts.length);
+
+  for (let i = 0; i < texts.length; i += BATCH) {
+    const chunk = texts.slice(i, i + BATCH);
+    const response = await fetch(
+      `${GEMINI_API_BASE}/models/${EMBEDDING_MODEL}:batchEmbedContents?key=${apiKey()}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          requests: chunk.map((t) => ({
+            model: `models/${EMBEDDING_MODEL}`,
+            content: { parts: [{ text: truncateForEmbedding(t) || " " }] },
+            taskType: taskTypeFor(inputType),
+            outputDimensionality: EMBEDDING_DIMENSIONS,
+          })),
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Gemini batch embed error ${response.status}: ${body.slice(0, 300)}`);
+    }
+
+    const data = (await response.json()) as { embeddings?: Array<{ values?: number[] }> };
+    const embs = data.embeddings;
+    if (!embs || embs.length !== chunk.length) {
+      throw new Error(`Gemini batch returned ${embs?.length ?? 0}, expected ${chunk.length}`);
+    }
+    for (let j = 0; j < chunk.length; j++) {
+      const values = embs[j]?.values;
+      if (!values || values.length !== EMBEDDING_DIMENSIONS) {
+        throw new Error(
+          `Gemini batch item ${j} ${values?.length ?? 0}-dim, expected ${EMBEDDING_DIMENSIONS}`,
+        );
+      }
+      results[i + j] = l2normalize(values);
+    }
+  }
+
+  return { embeddings: results, count: results.length };
+}

--- a/convex/palace/queries.ts
+++ b/convex/palace/queries.ts
@@ -7,7 +7,7 @@
 import { query, internalQuery } from "../_generated/server.js";
 import { v } from "convex/values";
 import type { Id, Doc } from "../_generated/dataModel.js";
-import { embedderConfigured, EMBEDDER_PROVIDER, EMBEDDER_ENV_KEY } from "../lib/qwen.js";
+import { embedderConfigured, EMBEDDER_PROVIDER, EMBEDDER_ENV_KEY } from "../lib/embedder.js";
 
 // ─── PALACES ─────────────────────────────────────────────────
 

--- a/convex/serving/search.ts
+++ b/convex/serving/search.ts
@@ -23,7 +23,7 @@ import { action } from "../_generated/server.js";
 import { internal } from "../_generated/api.js";
 import { v } from "convex/values";
 import type { Id, Doc } from "../_generated/dataModel.js";
-import { embedOne } from "../lib/qwen.js";
+import { embedOne } from "../lib/embedder.js";
 import { graphSearch, buildGraphBoostMap } from "../lib/graphClient.js";
 
 // Bedrock Titan v2 score distribution (observed empirically, April 2026):

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, test } from "vitest";
 import { convexTest } from "convex-test";
 import { api } from "../convex/_generated/api.js";
 import schema from "../convex/schema.js";
+import { EMBEDDER_ENV_KEY } from "../convex/lib/embedder.js"; // provider-agnostic: survives provider switches
 
 const EMBED_DIM = 1024; // Bedrock Titan Text Embeddings v2
 const fakeEmbedding = (): number[] => Array.from({ length: EMBED_DIM }, () => Math.random());
@@ -551,8 +552,8 @@ describe("Gate B-2 — owner-namespaced room resolution", () => {
 
 describe("#6 — embedding health (silent-degradation visibility)", () => {
   test("flags an unconfigured embedder (retrieval would be blind)", async () => {
-    const saved = process.env.AWS_BEARER_TOKEN_BEDROCK;
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const saved = process.env[EMBEDDER_ENV_KEY];
+    delete process.env[EMBEDDER_ENV_KEY];
     try {
       const t = convexTest(schema);
       const { palaceId } = await makePalace(t);
@@ -561,13 +562,13 @@ describe("#6 — embedding health (silent-degradation visibility)", () => {
       expect(h.degraded).toBe(true);
       expect(h.reason).toMatch(/credential absent/i);
     } finally {
-      if (saved !== undefined) process.env.AWS_BEARER_TOKEN_BEDROCK = saved;
+      if (saved !== undefined) process.env[EMBEDDER_ENV_KEY] = saved;
     }
   });
 
   test("surfaces failed embeddings even when the embedder is configured", async () => {
-    const saved = process.env.AWS_BEARER_TOKEN_BEDROCK;
-    process.env.AWS_BEARER_TOKEN_BEDROCK = "test-token";
+    const saved = process.env[EMBEDDER_ENV_KEY];
+    process.env[EMBEDDER_ENV_KEY] = "test-token";
     try {
       const t = convexTest(schema);
       const { palaceId, roomId } = await makePalace(t);
@@ -586,8 +587,8 @@ describe("#6 — embedding health (silent-degradation visibility)", () => {
       expect(h.degraded).toBe(true);   // failed > 0
       expect(h.reason).toMatch(/failed to embed/i);
     } finally {
-      if (saved === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
-      else process.env.AWS_BEARER_TOKEN_BEDROCK = saved;
+      if (saved === undefined) delete process.env[EMBEDDER_ENV_KEY];
+      else process.env[EMBEDDER_ENV_KEY] = saved;
     }
   });
 });


### PR DESCRIPTION
The wired embedder was Bedrock Titan but **unauthenticated/untested** → live retrieval was dead (the deployed-stack smoke passed *because* it tolerates graceful-empty). This makes retrieval actually work on the no-NAT AWS spine.

## What
- `lib/embedder.ts` — single active-provider selector (the one place the embedder is chosen).
- **active: `lib/qwen.js`** (Bedrock Titan v2, 1024-d, server-normalized) — reached via the `bedrock-runtime` PrivateLink VPC endpoint, **no internet/NAT**. Verified: Titan embeddings ARE available on this account (the "Bedrock blocked" note was stale).
- **parked: `lib/gemini.js`** (new; gemini-embedding-001, 1024-d, client L2-normalized) — correct code, but Google's API has no VPC endpoint → needs NAT. One-line switch if an EIP/NAT lands.
- **planned: Voyage** — named forward-dependency (switch cheap; re-embed if dims/space differ).
- Repointed the 3 importers (ingest/queries/search) to the selector; tests made provider-agnostic via `EMBEDDER_ENV_KEY`.

## Proven
Ranked semantic retrieval on the live AWS stack (NEURAL-ops `tools/embedder_proof.py`): zero-lexical-overlap query → correct doc ranked top. tsc clean; vitest 95 pass | 1 skip.

Key lives in the **Convex** deployment env (`convex env set AWS_BEARER_TOKEN_BEDROCK`), not the runtime container — embeddings compute server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)