### PR TITLE
feat(M1/D1): Gemini embedder @768 (canonical V1 embedder) — ranking-proven

### DIFF
--- a/convex/lib/embedder.ts
+++ b/convex/lib/embedder.ts
@@ -17,4 +17,7 @@
 // Provider libs MUST export the same surface: EMBEDDING_MODEL · EMBEDDING_DIMENSIONS · EMBEDDER_PROVIDER ·
 // EMBEDDER_ENV_KEY · embedderConfigured · truncateForEmbedding · embedOne · embedBatchTexts · EmbedInputType.
 
-export * from "./qwen.js";
+// M1/D1: Gemini @768 is the canonical V1 embedder. NOTE: do NOT deploy this branch to the live no-NAT
+// AWS spine — Gemini is unreachable there (no internet egress); that spine stays on qwen.js (Titan@1024)
+// until a NAT gateway lands. This selector is for dev + the post-NAT live flip (empty corpus = free re-index).
+export * from "./gemini.js";

--- a/convex/lib/gemini.ts
+++ b/convex/lib/gemini.ts
@@ -1,11 +1,13 @@
 // Gemini text embeddings — embedding provider (the unblocked path; Bedrock Titan is account-blocked).
 //
 // Model:    gemini-embedding-001  (Google Generative Language API, v1beta)
-// Dims:     1024  — matches the schema `by_embedding` vector index EXACTLY (no re-index).
-//           gemini-embedding-001 supports outputDimensionality (Matryoshka); we request 1024.
+// Dims:     768  — matches the schema `by_embedding` vector index (V1 spec D1). gemini-embedding-001 is
+//           3072 native; we request 768 via outputDimensionality (Matryoshka). NOTE: the spec said
+//           "native embedding-001 @ 768", but `models/embedding-001` + `models/text-embedding-004` both
+//           404 on this key — only gemini-embedding-001 is available, so MRL-768 is the achievable 768.
 // Norm:     CLIENT-SIDE L2. Gemini only auto-normalizes at the full 3072-d output; at a truncated
-//           dimension it returns UN-normalized vectors (measured L2≈0.61 @1024). Cosine/dot retrieval
-//           needs unit vectors, so we normalize here — the silent-garbage failure class if skipped.
+//           dimension it returns UN-normalized vectors. Cosine/dot retrieval needs unit vectors, so we
+//           normalize here — the silent-garbage failure class if skipped.
 // Context:  ~2048 input tokens for this model (smaller than Titan's 8K) → tighter truncation.
 // Task:     uses taskType (RETRIEVAL_DOCUMENT / RETRIEVAL_QUERY) — the `inputType` arg that was a
 //           no-op for Titan is a real asymmetric-retrieval quality lever for Gemini.
@@ -17,7 +19,7 @@
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 export const EMBEDDING_MODEL = "gemini-embedding-001";
-export const EMBEDDING_DIMENSIONS = 1024;
+export const EMBEDDING_DIMENSIONS = 768;
 export const EMBEDDING_API_URL =
   `${GEMINI_API_BASE}/models/${EMBEDDING_MODEL}:embedContent`;
 

--- a/convex/palace/mutations.ts
+++ b/convex/palace/mutations.ts
@@ -14,6 +14,7 @@ import { mutation, internalMutation } from "../_generated/server.js";
 import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel.js";
 import { computeDedupKey, normalizeContent } from "../lib/dedup.js";
+import { EMBEDDING_DIMENSIONS } from "../lib/embedder.js";
 import {
   CATEGORY_TTL_DEFAULTS,
   HALL_TYPES,
@@ -881,13 +882,13 @@ export const storeEmbedding = mutation({
     modelVersion: v.string(),
   },
   handler: async (ctx, args) => {
-    // Dimension check — MUST match schema.ts vectorIndex dimensions AND lib/qwen.ts EMBEDDING_DIMENSIONS.
-    // If you change the embedding model, update all three locations.
-    // Bedrock Titan Text Embeddings v2: 1024 dims.
-    const EXPECTED_DIMS = 1024;
-    if (args.embedding.length !== EXPECTED_DIMS) {
+    // Dimension check — single source of truth: the active embedder's EMBEDDING_DIMENSIONS
+    // (lib/embedder.js re-exports the active provider; M1 = gemini @768). This MUST stay equal to the
+    // schema.ts `by_embedding` vectorIndex `dimensions`. Importing the constant (rather than a literal)
+    // prevents the drift that previously left this at 1024 after the schema/embedder moved to 768.
+    if (args.embedding.length !== EMBEDDING_DIMENSIONS) {
       throw new Error(
-        `embedding must be ${EXPECTED_DIMS}-dim, got ${args.embedding.length}`,
+        `embedding must be ${EMBEDDING_DIMENSIONS}-dim, got ${args.embedding.length}`,
       );
     }
     const closet = await ctx.db.get(args.closetId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -373,7 +373,7 @@ export default defineSchema({
     .index("by_closet", ["closetId"])
     .vectorIndex("by_embedding", {
       vectorField: "embedding",
-      dimensions: 1024,
+      dimensions: 768, // M1/D1: Gemini gemini-embedding-001 @768 (MRL). Free re-index — empty corpus.
       filterFields: ["palaceId", "wingId"],
     }),
 

--- a/tests/palace.test.ts
+++ b/tests/palace.test.ts
@@ -25,7 +25,7 @@ import { api } from "../convex/_generated/api.js";
 import schema from "../convex/schema.js";
 import { EMBEDDER_ENV_KEY } from "../convex/lib/embedder.js"; // provider-agnostic: survives provider switches
 
-const EMBED_DIM = 1024; // Bedrock Titan Text Embeddings v2
+const EMBED_DIM = 768; // M1/D1: Gemini gemini-embedding-001 @768 (MRL) — matches the by_embedding index
 const fakeEmbedding = (): number[] => Array.from({ length: EMBED_DIM }, () => Math.random());
 
 // Helper: create a fully-scaffolded palace with a single wing/hall/room.


### PR DESCRIPTION
M1 per V1 plan D1: native Gemini `gemini-embedding-001` @ **768-dim**, asymmetric task types (RETRIEVAL_DOCUMENT/QUERY), L2-normalized, server-side in Convex.

**DoD met — ranking sanity (not cardinality):** 3 distinct docs + a zero-lexical-overlap query → the related doc ranks **top (0.676)** above unrelated (0.47). vitest 95 pass / 1 skip.

Changes: `lib/gemini.ts` 1024→768 · `lib/embedder.ts` selector qwen→gemini · `schema.ts by_embedding` 1024→768 (free, empty corpus) · test EMBED_DIM→768.

**Flagged (confirmed-facts / D1):** "native 768" (`embedding-001`/`text-embedding-004`) 404s on this key → 768 is via gemini-embedding-001 **MRL** (the achievable 768).

⛔ **DO NOT deploy this branch to the live no-NAT AWS spine** — Gemini is unreachable there (no internet egress); that spine stays Titan@1024 via PrivateLink until a NAT gateway lands. This is the canonical/dev embedder + the post-NAT live flip (empty corpus = free re-index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)