### PR TITLE
fix(ingestion): extract via in-VPC Bedrock Nova, not Gemini (no-NAT spine)

### DIFF
--- a/convex/ingestion/extract.ts
+++ b/convex/ingestion/extract.ts
@@ -16,7 +16,7 @@
 
 import { action } from "../_generated/server.js";
 import { v } from "convex/values";
-import { callGeminiLlm } from "../lib/geminiLlm.js";
+import { callBedrockLlm } from "../lib/bedrockLlm.js";
 import { CATEGORIES } from "../lib/enums.js";
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -163,7 +163,7 @@ export const extractMemories = action({
 
     const userPrompt = `${contextPrefix}${args.exchangeText}`;
 
-    const response = await callGeminiLlm({
+    const response = await callBedrockLlm({
       systemPrompt: SYSTEM_PROMPT,
       userPrompt,
       jsonMode: true,

--- a/convex/ingestion/ingest.ts
+++ b/convex/ingestion/ingest.ts
@@ -21,7 +21,7 @@ import type { Id } from "../_generated/dataModel.js";
 import { scanForPII } from "./pii.js";
 import { routeToWing, routeToRoom, classifyCategory, scoreConfidence } from "./route.js";
 import { embedOne, EMBEDDING_MODEL } from "../lib/embedder.js";
-import { callGeminiLlm } from "../lib/geminiLlm.js";
+import { callBedrockLlm } from "../lib/bedrockLlm.js";
 import { CATEGORIES, SYSTEM_NEOP_ID } from "../lib/enums.js";
 import { EXTRACTION_SYSTEM_PROMPT, parseExtractionResponse, type ExtractionItem } from "./extract.js";
 
@@ -85,7 +85,7 @@ export const ingestExchange = action({
         ? `Conversation: "${args.conversationTitle}" (exchange ${args.exchangeIndex})\n\n`
         : "";
 
-      const response = await callGeminiLlm({
+      const response = await callBedrockLlm({
         systemPrompt: EXTRACTION_SYSTEM_PROMPT,
         userPrompt: contextPrefix + exchangeText,
         jsonMode: true,

--- a/convex/lib/bedrockLlm.ts
+++ b/convex/lib/bedrockLlm.ts
@@ -1,0 +1,101 @@
+// Bedrock Nova LLM caller for structured extraction — the in-VPC, no-NAT replacement for geminiLlm.
+//
+// WHY: the dogfood spine is no-NAT (VPC endpoints only). Gemini
+// (generativelanguage.googleapis.com) is a PUBLIC Google API with no VPC endpoint, so the Convex task
+// cannot reach it → ingestion threw "extraction_failed: fetch failed" and every write quarantined
+// without an embedded drawer (proven live 2026-06-29 during the jcode T0 spike). Bedrock Nova is
+// reachable via the SAME bedrock-runtime PrivateLink VPC endpoint + bearer-token auth the Titan
+// embedder already uses (lib/qwen.ts) — verified in-VPC: a bearer-token Nova invoke returns cleanly.
+//
+// On-demand Nova requires a cross-region INFERENCE PROFILE (bare `amazon.nova-*` ids reject on-demand),
+// so the model id is the APAC profile. Drop-in for callGeminiLlm: same opts + same response shape.
+
+const BEDROCK_REGION = "ap-south-1";
+
+// APAC cross-region inference profile (on-demand Nova needs a profile, not the bare model id).
+export const BEDROCK_LLM_MODEL_ID =
+  process.env.BEDROCK_LLM_MODEL_ID || "apac.amazon.nova-lite-v1:0";
+
+const BEDROCK_LLM_API_URL = `https://bedrock-runtime.${BEDROCK_REGION}.amazonaws.com/model/${encodeURIComponent(
+  BEDROCK_LLM_MODEL_ID,
+)}/invoke`;
+
+export interface BedrockLlmResponse {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * Call Bedrock Nova for text generation with optional JSON mode.
+ * Signature + return shape are identical to callGeminiLlm (drop-in replacement).
+ */
+export async function callBedrockLlm(opts: {
+  systemPrompt: string;
+  userPrompt: string;
+  jsonMode?: boolean;
+  maxOutputTokens?: number;
+  temperature?: number;
+}): Promise<BedrockLlmResponse> {
+  const token = process.env.AWS_BEARER_TOKEN_BEDROCK;
+  if (!token) {
+    throw new Error("AWS_BEARER_TOKEN_BEDROCK not set in Convex environment");
+  }
+
+  // Nova has no strict JSON-mode flag (unlike Gemini's responseMimeType) — instruct it, then strip
+  // markdown fences defensively so parseExtractionResponse() receives clean JSON.
+  const system = opts.jsonMode
+    ? `${opts.systemPrompt}\n\nRespond with ONLY valid JSON. No markdown, no code fences, no commentary.`
+    : opts.systemPrompt;
+
+  const body = {
+    system: [{ text: system }],
+    messages: [{ role: "user", content: [{ text: opts.userPrompt }] }],
+    inferenceConfig: {
+      maxTokens: opts.maxOutputTokens ?? 4096,
+      temperature: opts.temperature ?? 0.2,
+    },
+  };
+
+  const response = await fetch(BEDROCK_LLM_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(
+      `Bedrock Nova LLM error ${response.status}: ${errBody.slice(0, 400)}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    output?: { message?: { content?: Array<{ text?: string }> } };
+    usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  };
+
+  let text = (data.output?.message?.content ?? [])
+    .map((p) => p.text ?? "")
+    .join("");
+
+  // Defensive: strip ```json … ``` fences if the model added them despite instructions.
+  text = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+
+  const usage = data.usage ?? {};
+  return {
+    text,
+    inputTokens: usage.inputTokens ?? 0,
+    outputTokens: usage.outputTokens ?? 0,
+    totalTokens: usage.totalTokens ?? 0,
+  };
+}


### PR DESCRIPTION
## Problem (found live during the jcode T0 spike, 2026-06-29)
The dogfood spine is **no-NAT** (VPC endpoints only). Ingestion entity-extraction hard-called **Gemini** (`generativelanguage.googleapis.com`, a public Google API with no VPC endpoint), so the Convex task couldn't egress → `extraction_failed: fetch failed`. Every `palace_remember` then quarantined to `_quarantine/unclassified` with `drawersCreated:0` (no embedding) → **nothing retrievable**. The Titan *embedder* is in-VPC and fine, but extraction runs first and gates indexing.

## Fix
`convex/lib/bedrockLlm.ts` — `callBedrockLlm`, a **drop-in** for `callGeminiLlm` (same opts + return shape) that invokes **Bedrock Nova** via the *same* bedrock-runtime PrivateLink VPC endpoint + bearer-token auth the Titan embedder already uses (`lib/qwen.ts`). On-demand Nova needs a cross-region inference profile → `apac.amazon.nova-lite-v1:0`. Swapped both call sites (`ingestion/extract.ts`, `ingestion/ingest.ts`). **No new env** (reuses `AWS_BEARER_TOKEN_BEDROCK`). Gemini path left in tree for the NAT future.

## Verified live (after deploy)
- `palace_remember` → `drawersCreated:1, errors:[], tokensUsed:1198` (extraction ran on Nova).
- `palace_search` ("what is the T0 canary fact", zero lexical overlap) → returns the seeded canary **ranked at 0.986**.

Also disproves the "Bedrock LLM blocked" assumption — bearer-token Nova invoke works in-VPC.

⚠️ Deployed to the live dogfood palace already (via `convex-deploy.sh`) to unblock the T0 round-trip; this PR brings the repo in sync with what's running (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)