### PR TITLE
feat(search): recency fallback — route fresh writes around the async index-propagation stall

### DIFF
--- a/convex/lib/fusion.ts
+++ b/convex/lib/fusion.ts
@@ -1,0 +1,121 @@
+// Pure ranking/gating fusion for palace search — EXTRACTED from search.ts ("use node") so the load-bearing
+// scoring + adaptive-floor gate + MMR-lite diversification is UNIT-TESTABLE without the vectorSearch action.
+//
+// Why this exists (2026-07-01, post-mortem): the recency fallback shipped with its fusion logic inline in a
+// "use node" action that convex-test can't run, so its live behavior was unprovable offline — it went to a
+// live palace unverified and, on an already-broken index, looked like a total failure. This module makes the
+// exact decision path testable: given scored candidates (vector / recency / lexical), does a clear-cosine
+// fresh-write candidate survive when the vector channel is empty? does off-domain garbage stay filtered?
+//
+// The gate is ADAPTIVE (ADR-neop-runtime GAP-1 fix): keepThreshold = max(NOISE_FLOOR, topRaw × ratio).
+// rawRelevance = vector+graph ONLY (bonuses excluded from the gate). Lexical hits bypass the floor.
+
+export const DEFAULT_SIMILARITY_FLOOR = 0.2; // NOISE_FLOOR — absolute minimum; preserves "I don't know"
+export const RELATIVE_KEEP_RATIO = 0.5; // keep within this fraction of the top raw relevance
+export const GRAPH_BOOST_PER_ENTITY = 0.05;
+export const GRAPH_BOOST_MAX = 0.2;
+export const LEXICAL_WEIGHT = 0.5;
+export const CONFIDENCE_WEIGHT = 0.05;
+export const RECENCY_WEIGHT = 0.05;
+export const RECENCY_HALF_LIFE_DAYS = 90;
+export const SAME_ROOM_PENALTY = 0.03;
+
+export interface SearchResult {
+  closetId: string;
+  score: number;
+  content: string;
+  title?: string;
+  category: string;
+  wingId: string;
+  wingName: string;
+  roomId: string;
+  roomName: string;
+  createdAt: number;
+  sourceAdapter: string;
+  confidence: number;
+}
+
+// One candidate entering the fusion, already enriched + filtered (retracted/decayed/wing/category/time
+// filters applied upstream). vectorScore = cosine from the vector channel OR the recency channel's directly-
+// computed cosine OR 0 (lexical-only). graphMatchCount = entities matched (→ graphBoost). lexicalRank
+// undefined ⇒ not a lexical hit (so it does NOT bypass the floor).
+export interface FusionInput {
+  closetId: string;
+  content: string;
+  title?: string;
+  category: string;
+  wingId: string;
+  wingName: string;
+  roomId: string;
+  roomName: string;
+  createdAt: number;
+  sourceAdapter: string;
+  confidence: number;
+  vectorScore: number;
+  graphMatchCount: number;
+  lexicalRank?: number;
+}
+
+// Gentle recency decay, half-life 90d. `now` injected (not Date.now()) so the fusion is deterministic/testable.
+export function recencyFactor(createdAt: number, now: number): number {
+  const ageDays = (now - createdAt) / 86_400_000;
+  return Math.exp(-ageDays / RECENCY_HALF_LIFE_DAYS);
+}
+
+export interface FusionOpts {
+  similarityFloor: number;
+  limit: number;
+  now: number;
+}
+
+// Score → adaptive-floor gate → rank → MMR-lite diversify. Pure; identical math to the prior inline path.
+export function fuseAndRank(inputs: FusionInput[], opts: FusionOpts): SearchResult[] {
+  const scored = inputs.map((i) => {
+    const graphBoost = Math.min(i.graphMatchCount * GRAPH_BOOST_PER_ENTITY, GRAPH_BOOST_MAX);
+    const isLexical = i.lexicalRank !== undefined;
+    const lexicalBoost = isLexical ? LEXICAL_WEIGHT / (1 + (i.lexicalRank as number)) : 0;
+    const confidenceBoost = i.confidence * CONFIDENCE_WEIGHT;
+    const recencyBoost = recencyFactor(i.createdAt, opts.now) * RECENCY_WEIGHT;
+    const score = i.vectorScore + graphBoost + lexicalBoost + confidenceBoost + recencyBoost;
+    // rawRelevance = vector+graph ONLY (bonuses excluded from the gate so a fresh/confident closet can't
+    // sneak past the floor on an unrelated query).
+    const rawRelevance = i.vectorScore + graphBoost;
+    return { i, score, rawRelevance, isLexical };
+  });
+
+  // ADAPTIVE floor: noise floor preserves "I don't know"; relative term drops the weak tail. Lexical bypasses.
+  const topRaw = scored.reduce((m, s) => Math.max(m, s.rawRelevance), 0);
+  const keepThreshold = Math.max(opts.similarityFloor, topRaw * RELATIVE_KEEP_RATIO);
+  const kept = scored.filter((s) => s.isLexical || s.rawRelevance >= keepThreshold);
+  kept.sort((a, b) => b.score - a.score);
+
+  // MMR-lite: greedy same-room penalty so top-K spans rooms.
+  const diversified: typeof kept = [];
+  const roomCount = new Map<string, number>();
+  const pool = [...kept];
+  while (diversified.length < opts.limit && pool.length > 0) {
+    pool.sort((a, b) => {
+      const penA = (roomCount.get(a.i.roomId) ?? 0) * SAME_ROOM_PENALTY;
+      const penB = (roomCount.get(b.i.roomId) ?? 0) * SAME_ROOM_PENALTY;
+      return (b.score - penB) - (a.score - penA);
+    });
+    const pick = pool.shift() as (typeof kept)[number];
+    diversified.push(pick);
+    roomCount.set(pick.i.roomId, (roomCount.get(pick.i.roomId) ?? 0) + 1);
+  }
+
+  return diversified.map((s) => ({
+    closetId: s.i.closetId,
+    score: s.score,
+    content: s.i.content,
+    title: s.i.title,
+    category: s.i.category,
+    wingId: s.i.wingId,
+    wingName: s.i.wingName,
+    roomId: s.i.roomId,
+    roomName: s.i.roomName,
+    createdAt: s.i.createdAt,
+    sourceAdapter: s.i.sourceAdapter,
+    confidence: s.i.confidence,
+  }));
+}

--- a/convex/lib/vec.ts
+++ b/convex/lib/vec.ts
@@ -1,0 +1,20 @@
+// Vector helpers shared by the serving layer. Kept out of search.ts ("use node") so pure math is unit-
+// testable without pulling the action's runtime.
+
+// Cosine similarity for the recency fallback (ADR-neop-runtime index-propagation fix) — MUST match Convex
+// vectorSearch's `_score` metric (cosine) so recency-scored candidates are comparable to vector-scored ones
+// in the same fusion. Titan v2 vectors are server-normalized (cosine == dot), but we normalize defensively
+// so the two channels never diverge. Returns 0 on length mismatch / zero vector (never NaN).
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i] as number;
+    const y = b[i] as number;
+    dot += x * y;
+    na += x * x;
+    nb += y * y;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}

--- a/convex/serving/enrich.ts
+++ b/convex/serving/enrich.ts
@@ -35,6 +35,37 @@ export const lexicalSearchClosets = internalQuery({
   },
 });
 
+// Recency fallback (ADR-neop-runtime index-propagation fix). The async vector/search indexes lag on the
+// self-hosted backend (stall-leaning: a just-written closet can be invisible to vector+lexical search for
+// 30min+ — box-proven 2026-07-01), so a fresh write is unrecallable until its index entry builds. This
+// returns the last-N closets by createdAt via the TRANSACTIONAL `by_time` index, WITH each closet's stored
+// embedding (the `closet_embeddings` row exists the instant `storeEmbedding` runs — only the vector INDEX is
+// async). coreSearch computes cosine against these directly, so fresh writes are recallable immediately,
+// scored by TRUE relevance (they surface when relevant, not always). Skips retracted/decayed/superseded.
+export const recentClosetsWithEmbeddings = internalQuery({
+  args: {
+    palaceId: v.id("palaces"),
+    limit: v.number(),
+  },
+  handler: async (ctx, { palaceId, limit }) => {
+    const recents = await ctx.db
+      .query("closets")
+      .withIndex("by_time", (q) => q.eq("palaceId", palaceId))
+      .order("desc") // most-recent createdAt first
+      .take(limit);
+    const out: Array<{ closetId: string; embedding: number[] }> = [];
+    for (const c of recents) {
+      if (c.retracted || c.decayed || c.supersededBy !== undefined) continue;
+      const emb = await ctx.db
+        .query("closet_embeddings")
+        .withIndex("by_closet", (q) => q.eq("closetId", c._id))
+        .first();
+      if (emb) out.push({ closetId: c._id as string, embedding: emb.embedding });
+    }
+    return out;
+  },
+});
+
 export const resolveEmbeddingIds = internalQuery({
   args: {
     embeddingIds: v.array(v.string()),

--- a/convex/serving/search.ts
+++ b/convex/serving/search.ts
@@ -25,6 +25,7 @@ import { v } from "convex/values";
 import type { Id, Doc } from "../_generated/dataModel.js";
 import { embedOne } from "../lib/embedder.js";
 import { graphSearch, buildGraphBoostMap } from "../lib/graphClient.js";
+import { cosineSimilarity } from "../lib/vec.js";
 
 // Bedrock Titan v2 score distribution (observed empirically, April 2026):
 //   relevant in-domain:     0.55 - 0.75
@@ -55,6 +56,14 @@ const GRAPH_BOOST_MAX = 0.2;
 // a criterion the cosine floor doesn't measure. Vector still handles pure-semantic paraphrase (which
 // already clears the 0.35 floor at ~0.36); lexical rescues exact-term and marginal-vector-but-on-topic.
 const LEXICAL_WEIGHT = 0.5;
+
+// Recency fallback window (ADR-neop-runtime index-propagation fix). The async vector/search indexes lag
+// (stall-leaning on the self-hosted backend), so the last-N closets by createdAt are additionally scored
+// via cosine computed directly from their transactionally-available stored embedding — routing fresh
+// writes around the async index. Bounds the extra per-query work; only recents NOT already found by the
+// vector channel are cosine-scored (an indexed recent is skipped). Supplements candidates, never overrides
+// ranking — a recency candidate is gated by the SAME adaptive floor on its true cosine.
+const RECENCY_WINDOW = 25;
 
 // Previously-unused signals now folded into ranking (Tier 1 quick-wins):
 //   - closet.confidence: extraction-quality proxy (high when Gemini/Llama
@@ -196,15 +205,10 @@ export async function coreSearch(
       filter: (q: any) => q.eq("palaceId", args.palaceId),
     });
 
-  if (vectorHits.length === 0) {
-    return {
-      results: [],
-      confidence: "low",
-      reason: "no_vector_hits",
-      tokenEstimate: 0,
-      queryTimeMs: Date.now() - t0,
-    };
-  }
+  // NOTE: no early return on empty vectorHits — a fresh write may be invisible to the async vector index
+  // yet recallable via the lexical channel (3b) or the recency fallback (3c). Bailing here would strand
+  // exactly the fresh-write case this path exists to serve; the real empty guard is `closetIds.length === 0`
+  // after all three channels have run.
 
   // 3. Resolve embedding doc IDs → closetIds via a query.
   //    vectorSearch only returns _id (embedding doc) + _score.
@@ -240,6 +244,23 @@ export async function coreSearch(
       closetIds.push(id as Id<"closets">);
       scoreMap.set(id, 0); // no vector score; surfaced via lexical boost + floor bypass
     }
+  }
+
+  // 3c. Recency fallback channel (ADR-neop-runtime index-propagation fix). The async vector/search indexes
+  //     lag (stall-leaning on the self-hosted backend — box-proven), so steps 2–3b can miss a just-written
+  //     closet until its index entry builds. Fetch the last-N by createdAt via the TRANSACTIONAL by_time
+  //     index WITH their stored embeddings (present the moment storeEmbedding ran — only the vector INDEX is
+  //     async) and score each with cosine computed directly here. A recency candidate already found by the
+  //     vector channel is skipped (the async index caught up). Its real cosine feeds the SAME fusion + gate
+  //     (NOT a floor bypass — we have true relevance) so a fresh fact surfaces when relevant, never always.
+  const recents: Array<{ closetId: string; embedding: number[] }> = await ctx.runQuery(
+    internal.serving.enrich.recentClosetsWithEmbeddings,
+    { palaceId: args.palaceId, limit: RECENCY_WINDOW },
+  );
+  for (const rc of recents) {
+    if (scoreMap.has(rc.closetId)) continue; // already surfaced by the vector channel — index caught up
+    closetIds.push(rc.closetId as Id<"closets">);
+    scoreMap.set(rc.closetId, cosineSimilarity(queryEmbedding, rc.embedding));
   }
 
   // Note: graph results are only used to re-rank vector hits (step 5 boost).

--- a/convex/serving/search.ts
+++ b/convex/serving/search.ts
@@ -26,85 +26,31 @@ import type { Id, Doc } from "../_generated/dataModel.js";
 import { embedOne } from "../lib/embedder.js";
 import { graphSearch, buildGraphBoostMap } from "../lib/graphClient.js";
 import { cosineSimilarity } from "../lib/vec.js";
+import {
+  fuseAndRank,
+  DEFAULT_SIMILARITY_FLOOR,
+  type FusionInput,
+  type SearchResult,
+} from "../lib/fusion.js";
 
-// Bedrock Titan v2 score distribution (observed empirically, April 2026):
-//   relevant in-domain:     0.55 - 0.75
-//   weak in-domain:          0.45 - 0.55
-//   irrelevant/off-domain:   0.25 - 0.40
-//
-// ADAPTIVE FLOOR (ADR-neop-runtime GAP-1 fix, 2026-06-30). A FIXED absolute cosine floor is the root
-// error: cosine magnitudes are NOT comparable across query types (a lexical-overlap query's correct hit
-// scores ~0.9; a zero-overlap paraphrase's correct hit scores ~0.36 — both correct). The GAP-1 box proof
-// showed a legitimate #1 paraphrase at 0.358 sitting right at the old 0.35 floor. So gate by
-//   keepThreshold = max(NOISE_FLOOR, topRaw × RELATIVE_KEEP_RATIO)
-// NOISE_FLOOR is the ABSOLUTE minimum that preserves "I don't know" (empty when even the best hit is
-// off-domain garbage); the relative term ADAPTS to query type and drops the weak tail. Lexical hits
-// bypass entirely (they matched terms). NOISE_FLOOR is intentionally low (0.20, below legit paraphrase
-// ~0.36, above off-domain noise ~0.25-).
-const DEFAULT_SIMILARITY_FLOOR = 0.2; // = NOISE_FLOOR (absolute minimum; preserves "I don't know")
-const RELATIVE_KEEP_RATIO = 0.5; // keep results within this fraction of the top raw relevance
+// Scoring/gating/diversification constants + the adaptive-floor fusion now live in `lib/fusion.ts`
+// (pure + unit-tested — the load-bearing decision path is provable offline, unlike when it was inline in
+// this "use node" action). search.ts keeps only the orchestration knobs below.
 const DEFAULT_LIMIT = 5;
-
-// Graph-boost tuning. Each matching entity in a closet adds this to its vector
-// score; capped at GRAPH_BOOST_MAX. Keeps vector dominant but re-ranks ties.
-const GRAPH_BOOST_PER_ENTITY = 0.05;
-const GRAPH_BOOST_MAX = 0.2;
-
-// Hybrid lexical channel (ADR-neop-runtime GAP-1 floor fix). A full-text hit contributes
-// LEXICAL_WEIGHT / (1 + rank): a #1 lexical hit adds 0.5 (clears the cosine floor on its own), #2 adds
-// 0.25, etc. A lexical match ALSO bypasses the similarity floor — it matched terms, so it is relevant by
-// a criterion the cosine floor doesn't measure. Vector still handles pure-semantic paraphrase (which
-// already clears the 0.35 floor at ~0.36); lexical rescues exact-term and marginal-vector-but-on-topic.
-const LEXICAL_WEIGHT = 0.5;
 
 // Recency fallback window (ADR-neop-runtime index-propagation fix). The async vector/search indexes lag
 // (stall-leaning on the self-hosted backend), so the last-N closets by createdAt are additionally scored
 // via cosine computed directly from their transactionally-available stored embedding — routing fresh
-// writes around the async index. Bounds the extra per-query work; only recents NOT already found by the
-// vector channel are cosine-scored (an indexed recent is skipped). Supplements candidates, never overrides
-// ranking — a recency candidate is gated by the SAME adaptive floor on its true cosine.
+// writes around the async index. Only recents NOT already found by the vector channel are cosine-scored.
 const RECENCY_WINDOW = 25;
 
-// Previously-unused signals now folded into ranking (Tier 1 quick-wins):
-//   - closet.confidence: extraction-quality proxy (high when Gemini/Llama
-//     was confident). Slightly boosts well-extracted closets.
-//   - createdAt age: gentle recency decay, half-life 90 days. Lets fresh
-//     memories float up when two results tie on vector+graph.
-//   - same-room penalty: first result from a room pays nothing; subsequent
-//     results from the same room get docked. Cheap MMR-lite, prevents
-//     five near-duplicates dominating top-5.
-const CONFIDENCE_WEIGHT = 0.05;
-const RECENCY_WEIGHT = 0.05;
-const RECENCY_HALF_LIFE_DAYS = 90;
-const SAME_ROOM_PENALTY = 0.03;
-
-// Confidence thresholds recalibrated for Titan's compressed score range.
-// Previously 0.7/0.5 — tuned for Qwen3's wider distribution.
+// Confidence thresholds recalibrated for Titan's compressed score range (top final score → high/medium/low).
 const CONF_HIGH_THRESHOLD = 0.65;
 const CONF_MEDIUM_THRESHOLD = 0.50;
 
-function recencyFactor(createdAt: number): number {
-  const ageDays = (Date.now() - createdAt) / 86_400_000;
-  // Exponential decay: 1.0 at ingest, ~0.5 at half-life, ~0.25 at 2× half-life.
-  return Math.exp(-ageDays / RECENCY_HALF_LIFE_DAYS);
-}
+// ─── Types (SearchResult re-exported from lib/fusion) ───────────
 
-// ─── Types ──────────────────────────────────────────────────────
-
-export interface SearchResult {
-  closetId: string;
-  score: number;
-  content: string;
-  title?: string;
-  category: string;
-  wingId: string;
-  wingName: string;
-  roomId: string;
-  roomName: string;
-  createdAt: number;
-  sourceAdapter: string;
-  confidence: number;
-}
+export type { SearchResult };
 
 export interface SearchResponse {
   results: SearchResult[];
@@ -287,97 +233,45 @@ export async function coreSearch(
     closetIds,
   });
 
-  // 5. Score every candidate; gate ADAPTIVELY afterward (not a fixed absolute cosine — see the
-  //    DEFAULT_SIMILARITY_FLOOR comment). rawRelevance = vector+graph ONLY (bonuses excluded from the
-  //    gate so a fresh/confident closet can't sneak past on an unrelated query).
-  const scored: Array<{ result: SearchResult; rawRelevance: number; isLexical: boolean }> = [];
-
+  // 5. Build fusion inputs (apply retracted/decayed/superseded + wing/category/time filters here), then
+  //    hand off to the PURE fuseAndRank (lib/fusion) for scoring + adaptive-floor gate + MMR-lite diversify.
+  //    The decision path lives in fusion.ts so it is unit-testable without this "use node" action.
+  const fusionInputs: FusionInput[] = [];
   for (const item of enriched) {
     if (!item) continue;
     const { closet, wingName, roomName } = item;
 
-    // Skip retracted, decayed, older versions.
     if (closet.retracted) continue;
     if (closet.decayed) continue;
     if (closet.supersededBy !== undefined) continue;
-
-    // Wing filter (post-filter since vectorSearch only filters by palaceId).
     if (args.wingFilter && wingName !== args.wingFilter) continue;
-
-    // Category filter.
     if (args.categoryFilter && closet.category !== args.categoryFilter) continue;
-
-    // Time range filter (for searchTemporal).
     if (args.afterTs && closet.createdAt < args.afterTs) continue;
     if (args.beforeTs && closet.createdAt > args.beforeTs) continue;
 
-    const vectorScore = scoreMap.get(closet._id as string) ?? 0;
-    const graphBoost = Math.min(
-      (graphBoostMap.get(closet._id as string) ?? 0) * GRAPH_BOOST_PER_ENTITY,
-      GRAPH_BOOST_MAX,
-    );
-    // Hybrid lexical boost: rank-weighted (#1 = +0.5, #2 = +0.25, …). A lexical match also bypasses the
-    // adaptive floor below — it matched query terms (relevance cosine doesn't measure).
-    const lrank = lexicalRank.get(closet._id as string);
-    const isLexical = lrank !== undefined;
-    const lexicalBoost = isLexical ? LEXICAL_WEIGHT / (1 + lrank!) : 0;
-    const confidenceBoost = closet.confidence * CONFIDENCE_WEIGHT;
-    const recencyBoost = recencyFactor(closet.createdAt) * RECENCY_WEIGHT;
-    const score = vectorScore + graphBoost + lexicalBoost + confidenceBoost + recencyBoost;
-
-    scored.push({
-      rawRelevance: vectorScore + graphBoost,
-      isLexical,
-      result: {
-        closetId: closet._id,
-        score,
-        content: closet.content,
-        title: closet.title ?? undefined,
-        category: closet.category,
-        wingId: closet.wingId,
-        wingName,
-        roomId: closet.roomId,
-        roomName,
-        createdAt: closet.createdAt,
-        sourceAdapter: closet.sourceAdapter,
-        confidence: closet.confidence,
-      },
+    fusionInputs.push({
+      closetId: closet._id as string,
+      content: closet.content,
+      title: closet.title ?? undefined,
+      category: closet.category,
+      wingId: closet.wingId as string,
+      wingName,
+      roomId: closet.roomId as string,
+      roomName,
+      createdAt: closet.createdAt,
+      sourceAdapter: closet.sourceAdapter,
+      confidence: closet.confidence,
+      vectorScore: scoreMap.get(closet._id as string) ?? 0, // vector cosine OR recency-computed cosine OR 0
+      graphMatchCount: graphBoostMap.get(closet._id as string) ?? 0,
+      lexicalRank: lexicalRank.get(closet._id as string), // undefined ⇒ not a lexical hit
     });
   }
 
-  // 5b. ADAPTIVE floor: keepThreshold = max(NOISE_FLOOR, topRaw × RELATIVE_KEEP_RATIO). The noise floor
-  // (args.similarityFloor) preserves "I don't know" — if even the best hit is below it AND nothing matched
-  // lexically, results is empty rather than best-of-garbage. The relative term adapts to query type and
-  // drops the weak tail. Lexical hits always survive. (ADR-neop-runtime GAP-1 floor fix.)
-  const topRaw = scored.reduce((m, c) => Math.max(m, c.rawRelevance), 0);
-  const keepThreshold = Math.max(args.similarityFloor, topRaw * RELATIVE_KEEP_RATIO);
-  const results: SearchResult[] = scored
-    .filter((c) => c.isLexical || c.rawRelevance >= keepThreshold)
-    .map((c) => c.result);
-
-  // Re-rank by final score.
-  results.sort((a, b) => b.score - a.score);
-
-  // MMR-lite: apply same-room penalty greedily so top-K spans rooms.
-  // Pass 1: pick top result; Pass N: any subsequent pick from a room
-  // we've already picked from pays SAME_ROOM_PENALTY per prior pick,
-  // then we re-sort the remaining pool.
-  const diversified: SearchResult[] = [];
-  const roomCount = new Map<string, number>();
-  const pool = [...results];
-  while (diversified.length < args.limit && pool.length > 0) {
-    // Apply current penalty snapshot + re-rank pool.
-    pool.sort((a, b) => {
-      const penA = (roomCount.get(a.roomId) ?? 0) * SAME_ROOM_PENALTY;
-      const penB = (roomCount.get(b.roomId) ?? 0) * SAME_ROOM_PENALTY;
-      return (b.score - penB) - (a.score - penA);
-    });
-    const pick = pool.shift()!;
-    diversified.push(pick);
-    roomCount.set(pick.roomId, (roomCount.get(pick.roomId) ?? 0) + 1);
-  }
-  results.length = 0;
-  results.push(...diversified);
+  const results: SearchResult[] = fuseAndRank(fusionInputs, {
+    similarityFloor: args.similarityFloor,
+    limit: args.limit,
+    now: Date.now(),
+  });
 
   // 6. Determine overall confidence.
   let confidence: "high" | "medium" | "low" = "low";

--- a/tests/fusion.test.ts
+++ b/tests/fusion.test.ts
@@ -1,0 +1,93 @@
+// Fusion tests (ADR-neop-runtime) — the decision path that shipped UNPROVABLE offline (inline in a
+// "use node" action convex-test can't run) and broke a live palace. Now pure + tested. The load-bearing
+// case: does a clear-cosine RECENCY candidate survive when the vector channel is empty (the fresh-write
+// promise)? And does off-domain garbage stay filtered ("I don't know")?
+
+import { describe, expect, test } from "vitest";
+import { fuseAndRank, type FusionInput } from "../convex/lib/fusion.js";
+
+const NOW = 1_782_900_000_000;
+const base = (o: Partial<FusionInput>): FusionInput => ({
+  closetId: "c", content: "x", category: "fact", wingId: "w", wingName: "W",
+  roomId: "r", roomName: "R", createdAt: NOW, sourceAdapter: "t", confidence: 0.8,
+  vectorScore: 0, graphMatchCount: 0, lexicalRank: undefined, ...o,
+});
+const opts = (floor = 0.2, limit = 5) => ({ similarityFloor: floor, limit, now: NOW });
+
+describe("fuseAndRank — recency/vector-empty (the fresh-write promise)", () => {
+  test("clear-cosine recency candidate SURVIVES when the vector channel is empty", () => {
+    // Simulates the exact broken-index scenario: vector returned nothing, recency injected candidates
+    // scored by directly-computed cosine. The on-topic fresh write (0.5) must come back.
+    const inputs = [
+      base({ closetId: "fresh", content: "the fresh fact", vectorScore: 0.5, roomId: "r1" }),
+      base({ closetId: "noise1", vectorScore: 0.1, roomId: "r2" }),
+      base({ closetId: "noise2", vectorScore: 0.08, roomId: "r3" }),
+    ];
+    const out = fuseAndRank(inputs, opts());
+    expect(out.length).toBe(1);
+    expect(out[0]!.closetId).toBe("fresh");
+  });
+
+  test("two on-topic recency candidates both survive, ranked by score", () => {
+    const out = fuseAndRank([
+      base({ closetId: "a", vectorScore: 0.6, roomId: "r1" }),
+      base({ closetId: "b", vectorScore: 0.45, roomId: "r2" }),
+      base({ closetId: "junk", vectorScore: 0.1, roomId: "r3" }),
+    ], opts());
+    expect(out.map((r) => r.closetId)).toEqual(["a", "b"]); // junk (0.1 < keepThreshold 0.3) dropped
+  });
+});
+
+describe("fuseAndRank — 'I don't know' preserved", () => {
+  test("all off-domain (below noise floor) → empty", () => {
+    const out = fuseAndRank([
+      base({ closetId: "g1", vectorScore: 0.15, roomId: "r1" }),
+      base({ closetId: "g2", vectorScore: 0.12, roomId: "r2" }),
+    ], opts());
+    expect(out.length).toBe(0);
+  });
+
+  test("marginal zero-overlap paraphrase at 0.18 is filtered by the 0.2 noise floor (documents the boundary)", () => {
+    // This is the KNOWN GAP-1 boundary — not a bug. A fresh write whose true cosine is sub-floor is treated
+    // exactly like a settled one; the recency channel does not (and should not) force best-of-marginal.
+    const out = fuseAndRank([base({ closetId: "para", vectorScore: 0.18, roomId: "r1" })], opts());
+    expect(out.length).toBe(0);
+  });
+});
+
+describe("fuseAndRank — lexical bypass + adaptive floor", () => {
+  test("a lexical hit survives even with zero vector score (bypasses the floor)", () => {
+    const out = fuseAndRank([
+      base({ closetId: "lex", vectorScore: 0, lexicalRank: 0, roomId: "r1" }),
+      base({ closetId: "hi", vectorScore: 0.7, roomId: "r2" }),
+    ], opts());
+    expect(out.map((r) => r.closetId).sort()).toEqual(["hi", "lex"]);
+  });
+
+  test("relative term drops the weak tail below topRaw×0.5", () => {
+    // top 0.8 → keepThreshold = max(0.2, 0.4) = 0.4; 0.5 survives, 0.3 dropped.
+    const out = fuseAndRank([
+      base({ closetId: "top", vectorScore: 0.8, roomId: "r1" }),
+      base({ closetId: "mid", vectorScore: 0.5, roomId: "r2" }),
+      base({ closetId: "weak", vectorScore: 0.3, roomId: "r3" }),
+    ], opts());
+    expect(out.map((r) => r.closetId)).toEqual(["top", "mid"]);
+  });
+});
+
+describe("fuseAndRank — diversification + limit", () => {
+  test("same-room penalty lets a slightly-lower cross-room hit rank above a same-room duplicate", () => {
+    // r1: 0.80 and 0.78; r2: 0.79. After picking r1(0.80), r1(0.78) pays 0.03 → 0.75 < r2 0.79.
+    const out = fuseAndRank([
+      base({ closetId: "r1a", vectorScore: 0.80, roomId: "r1" }),
+      base({ closetId: "r1b", vectorScore: 0.78, roomId: "r1" }),
+      base({ closetId: "r2a", vectorScore: 0.79, roomId: "r2" }),
+    ], opts(0.2, 3));
+    expect(out.map((r) => r.closetId)).toEqual(["r1a", "r2a", "r1b"]);
+  });
+
+  test("honors the limit", () => {
+    const inputs = Array.from({ length: 6 }, (_, i) => base({ closetId: `c${i}`, vectorScore: 0.9 - i * 0.01, roomId: `room${i}` }));
+    expect(fuseAndRank(inputs, opts(0.2, 3)).length).toBe(3);
+  });
+});

--- a/tests/recency_fallback.test.ts
+++ b/tests/recency_fallback.test.ts
@@ -1,0 +1,132 @@
+// Recency fallback (ADR-neop-runtime index-propagation fix) — offline tests.
+//
+// The async vector/search indexes lag on the self-hosted backend (stall-leaning: a just-written closet can
+// be invisible to vector+lexical search for 30min+, box-proven 2026-07-01). The recency fallback routes
+// fresh writes around the async index using the TRANSACTIONAL by_time index + the closet's stored embedding
+// (present the instant storeEmbedding runs). These tests cover the two offline-provable halves:
+//   1. cosineSimilarity — the metric that MUST match Convex vectorSearch's cosine _score.
+//   2. recentClosetsWithEmbeddings — the transactional fetch returns a just-written+embedded closet
+//      immediately, skips un-embedded ones, and orders most-recent-first.
+// The full coreSearch fusion (vectorSearch/searchIndex) is proven LIVE on the box (convex-test can't run
+// vector/search indexes) — that live fresh-write recall is the done-bar this fix exists to close.
+
+import { describe, expect, test } from "vitest";
+import { convexTest } from "convex-test";
+import { api, internal } from "../convex/_generated/api.js";
+import schema from "../convex/schema.js";
+import { cosineSimilarity } from "../convex/lib/vec.js";
+
+const EMBED_DIM = 1024;
+const unit = (seed: number): number[] => {
+  // deterministic non-zero vector
+  const v = Array.from({ length: EMBED_DIM }, (_, i) => Math.sin(seed * (i + 1)));
+  return v;
+};
+
+describe("cosineSimilarity (recency-channel metric)", () => {
+  test("identical vectors → 1", () => {
+    const v = unit(1);
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1, 6);
+  });
+  test("opposite vectors → -1", () => {
+    const v = unit(2);
+    const neg = v.map((x) => -x);
+    expect(cosineSimilarity(v, neg)).toBeCloseTo(-1, 6);
+  });
+  test("scale-invariant (normalized)", () => {
+    const v = unit(3);
+    const scaled = v.map((x) => x * 7.5);
+    expect(cosineSimilarity(v, scaled)).toBeCloseTo(1, 6);
+  });
+  test("orthogonal → ~0", () => {
+    const a = [1, 0, 0, 0];
+    const b = [0, 1, 0, 0];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0, 6);
+  });
+  test("length mismatch / empty → 0 (never NaN)", () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2])).toBe(0);
+    expect(cosineSimilarity([], [])).toBe(0);
+    expect(cosineSimilarity([0, 0], [0, 0])).toBe(0);
+  });
+});
+
+async function makePalace(t: ReturnType<typeof convexTest>) {
+  const palaceId = await t.mutation(api.palace.mutations.createPalace, {
+    name: "Recency Palace", clientId: "test", falkordbGraph: "test_graph", createdBy: "system",
+  });
+  const wingId = await t.mutation(api.palace.mutations.createWing, {
+    palaceId, name: "platform", description: "Platform wing", sortOrder: 1,
+  });
+  const hallId = await t.mutation(api.palace.mutations.createHall, { wingId, palaceId, type: "facts" });
+  const roomId = await t.mutation(api.palace.mutations.createRoom, {
+    hallId, wingId, palaceId, name: "stack", summary: "Tech stack", tags: [],
+  });
+  await t.mutation(api.palace.mutations.markPalaceReady, { palaceId });
+  return { palaceId, roomId };
+}
+
+const closetArgs = (palaceId: string, roomId: string, o: Record<string, unknown> = {}) => ({
+  palaceId, roomId, content: "seed", category: "fact", sourceType: "claude_chat",
+  sourceAdapter: "test", sourceExternalId: "x", authorType: "adapter", authorId: "test",
+  confidence: 0.8, actorNeopId: "_system", ...o,
+});
+
+async function embed(t: ReturnType<typeof convexTest>, palaceId: string, closetId: string, seed: number) {
+  await t.mutation(api.palace.mutations.storeEmbedding, {
+    closetId: closetId as any, palaceId: palaceId as any,
+    embedding: unit(seed), model: "test", modelVersion: "001",
+  });
+}
+
+describe("recentClosetsWithEmbeddings (transactional recency fetch)", () => {
+  test("returns a just-written+embedded closet immediately, with its embedding", async () => {
+    const t = convexTest(schema);
+    const { palaceId, roomId } = await makePalace(t);
+    const { closetId } = await t.mutation(
+      api.palace.mutations.createCloset, closetArgs(palaceId, roomId, { content: "fresh fact", sourceExternalId: "c1" }) as any);
+    await embed(t, palaceId, closetId, 1);
+
+    const out = await t.query(internal.serving.enrich.recentClosetsWithEmbeddings, {
+      palaceId: palaceId as any, limit: 25,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]!.closetId).toBe(closetId);
+    expect(out[0]!.embedding.length).toBe(EMBED_DIM);
+  });
+
+  test("skips closets that have no embedding row", async () => {
+    const t = convexTest(schema);
+    const { palaceId, roomId } = await makePalace(t);
+    const a = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomId, { content: "embedded", sourceExternalId: "a" }) as any);
+    await embed(t, palaceId, a.closetId, 1);
+    // second closet, NO storeEmbedding → must be skipped (nothing to cosine against)
+    await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomId, { content: "unembedded", sourceExternalId: "b" }) as any);
+
+    const out = await t.query(internal.serving.enrich.recentClosetsWithEmbeddings, {
+      palaceId: palaceId as any, limit: 25,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]!.closetId).toBe(a.closetId);
+  });
+
+  test("orders most-recent-first and honors limit", async () => {
+    const t = convexTest(schema);
+    const { palaceId, roomId } = await makePalace(t);
+    const first = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomId, { content: "older", sourceExternalId: "f" }) as any);
+    await embed(t, palaceId, first.closetId, 1);
+    const second = await t.mutation(api.palace.mutations.createCloset, closetArgs(palaceId, roomId, { content: "newer", sourceExternalId: "s" }) as any);
+    await embed(t, palaceId, second.closetId, 2);
+
+    const out = await t.query(internal.serving.enrich.recentClosetsWithEmbeddings, {
+      palaceId: palaceId as any, limit: 25,
+    });
+    expect(out.length).toBe(2);
+    expect(out[0]!.closetId).toBe(second.closetId); // most-recent first
+
+    const limited = await t.query(internal.serving.enrich.recentClosetsWithEmbeddings, {
+      palaceId: palaceId as any, limit: 1,
+    });
+    expect(limited.length).toBe(1);
+    expect(limited[0]!.closetId).toBe(second.closetId);
+  });
+});


### PR DESCRIPTION
## Why
Box-proven 2026-07-01: Convex vector+search indexes update **asynchronously** on the self-hosted backend, **stall-leaning** — a just-written, fully-embedded closet was invisible to `palace_search` for **30 min+** (not embed latency/failure — `embeddingHealth`=generated). A sibling written seconds apart indexed in ~14s; neither query nor write activity flushed the laggard. That's the write→recall **amnesia window** M1b's proof never exercised (GAP-1 wrote-*then-waited* into a settled state).

## Fix — recency fallback channel
Fetch the last-N closets by `createdAt` via the **transactional** `by_time` index **with** their stored embeddings (the `closet_embeddings` row exists the instant `storeEmbedding` runs — only the vector *index* is async), and score each with cosine computed directly. A recency candidate already found by the vector channel is skipped. Its **real cosine** feeds the **same fusion + adaptive floor** (not a floor bypass — we have true relevance), so a fresh fact **surfaces when relevant, never always** ("I don't know" preserved). Also removes the empty-`vectorHits` early return that bailed *before* the lexical and recency channels — a latent bug that stranded exactly the fresh-write case.

- `enrich.ts`: `recentClosetsWithEmbeddings` internalQuery (transactional).
- `search.ts`: recency channel (3c) + `cosineSimilarity` import; empty-vector early-return removed.
- `lib/vec.ts`: `cosineSimilarity` (extracted, unit-testable; matches Convex cosine `_score`).
- `tests/recency_fallback.test.ts`: 8 tests (cosine metric + transactional recency fetch). **Full suite 103 pass, tsc clean.**

## Done-bar / gating
**DO-NOT-MERGE until the live fresh-write proof on the box** — write a fact, *immediately* `palace_search`, confirm it returns via the recency channel **before** the async index propagates. That proof **is** the fresh-write gap M1b left open (convex-test can't run vector/search indexes, so the fusion is proven live, not offline).

## Companion (not in this PR)
The reconciliation fix for the **generated-but-unindexed tail** (closets that age out of the recency window and never index) is **box-session work** — its repair mechanism ("whatever forces re-indexing") is unknown until the worker is rooted (the experiment proved writes/queries don't flush it). Building it now would be building past verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)