### PR TITLE
feat(palace): INTERIM run_events store + palace_get/put_run_event (Track 3 fidelity)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -40,6 +40,7 @@ import type * as palace_mutations from "../palace/mutations.js";
 import type * as palace_pausedRuns from "../palace/pausedRuns.js";
 import type * as palace_provision from "../palace/provision.js";
 import type * as palace_queries from "../palace/queries.js";
+import type * as palace_runEvents from "../palace/runEvents.js";
 import type * as palace_twins from "../palace/twins.js";
 import type * as serving_assemble from "../serving/assemble.js";
 import type * as serving_enrich from "../serving/enrich.js";
@@ -90,6 +91,7 @@ declare const fullApi: ApiFromModules<{
   "palace/pausedRuns": typeof palace_pausedRuns;
   "palace/provision": typeof palace_provision;
   "palace/queries": typeof palace_queries;
+  "palace/runEvents": typeof palace_runEvents;
   "palace/twins": typeof palace_twins;
   "serving/assemble": typeof serving_assemble;
   "serving/enrich": typeof serving_enrich;

--- a/convex/access/enforce.ts
+++ b/convex/access/enforce.ts
@@ -292,9 +292,11 @@ const TOOL_TO_OP: Record<string, string> = {
   palace_walk_tunnel: "recall",
   palace_stats: "recall",
   palace_get_paused_run: "recall",
+  palace_get_run_events: "recall",       // INTERIM fidelity event store (Track 3); own-seat read
 
   // Write ops → remember
   palace_remember: "remember",
+  palace_put_run_event: "remember",      // INTERIM fidelity event store (Track 3); own-seat append
   palace_save_paused_run: "remember",
   palace_resolve_paused_run: "remember",
   palace_add_closet: "remember",

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -456,6 +456,29 @@ async function dispatch(
         status: (params.status as string) ?? "resolved",
       });
 
+    // ── RUN EVENTS (INTERIM shadow-prediction store for the fidelity clock; Track 3) ──
+    // Same own-seat discipline as twins/paused_runs: neopId is server-overwritten, get→recall /
+    // put→remember already gated. A caller reads/writes ONLY its own events. INTERIM store — the
+    // durable event corpus moves to ClickHouse when the comms tier lands (Track 2).
+    case "palace_get_run_events":
+      return ctx.runQuery(api.palace.runEvents.getRunEvents, {
+        palaceId,
+        neopId,
+        kind: params.kind as string | undefined,
+        limit: params.limit as number | undefined,
+      });
+
+    case "palace_put_run_event":
+      // Blind append; runtime owns the event shape (no server-side validation). Bounded per seat.
+      return ctx.runMutation(api.palace.runEvents.putRunEvent, {
+        palaceId,
+        neopId,
+        kind: params.kind as string,
+        event: params.event,
+        runId: params.runId as string | undefined,
+        ts: params.ts as number | undefined,
+      });
+
     // ── STORAGE ───────────────────────────────────────────
     // palace_remember routes through the TRUSTED ingestion pipeline (ingestExchange →
     // getOrCreateRoom → createCloset), which bypasses the per-room write guards by design.

--- a/convex/palace/runEvents.ts
+++ b/convex/palace/runEvents.ts
@@ -1,0 +1,74 @@
+// Run-event accessors — the INTERIM shadow-prediction store for the fidelity clock (Track 3), ADDRESSED
+// by (palaceId, neopId). The runtime (NEOS core.py) owns the `event` shape (predicted/actual/class); the
+// server is a BLIND store, exactly like twins / paused_runs — no validation, append on write.
+//
+// INTERIM BY DESIGN: this exists so the fidelity clock can warm BEFORE the comms tier lands. The durable
+// event corpus MOVES to ClickHouse when enable_comms_tier applies (Track 2) — do NOT grow features on this
+// table; it is a stopgap the runner's load_events reads until the bus/columnar sink exists. Bounded on
+// write (per-seat cap) so Convex never becomes the event firehose (that is exactly ClickHouse's job); the
+// read is bounded too. Seat isolation is enforced upstream: the /mcp handler overwrites neopId server-side
+// and gates get→recall / put→remember, so a caller can only reach its OWN events (same discipline as twins).
+
+import { query, mutation } from "../_generated/server.js";
+import { v } from "convex/values";
+
+// Per-(palaceId, neopId) retention bound. Interim only — ClickHouse holds the full corpus post-Track-2.
+const RUN_EVENT_CAP = 1000;
+const READ_DEFAULT = 200;
+
+// palace_get_run_events → { events: [<event>...], count }. Newest-first, bounded, optional `kind` filter.
+// Keyed by the server-derived (palaceId, neopId): a caller reads only its OWN events.
+export const getRunEvents = query({
+  args: {
+    palaceId: v.id("palaces"),
+    neopId: v.string(),
+    kind: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { palaceId, neopId, kind, limit }) => {
+    const take = Math.min(Math.max(limit ?? READ_DEFAULT, 1), RUN_EVENT_CAP);
+    const rows = await ctx.db
+      .query("run_events")
+      .withIndex("by_palace_neop_ts", (q) => q.eq("palaceId", palaceId).eq("neopId", neopId))
+      .order("desc")
+      .take(take);
+    const events = rows.filter((r) => !kind || r.kind === kind).map((r) => r.event);
+    return { events, count: events.length };
+  },
+});
+
+// palace_put_run_event → { status, upsert:"insert", trimmed }. Append-only insert keyed by the
+// server-derived (palaceId, neopId). Bounded: after insert, trim rows beyond RUN_EVENT_CAP for this seat
+// (oldest first) so the table cannot grow without limit — the firehose is ClickHouse's job, not Convex's.
+export const putRunEvent = mutation({
+  args: {
+    palaceId: v.id("palaces"),
+    neopId: v.string(),
+    kind: v.string(),
+    event: v.any(),
+    runId: v.optional(v.string()),
+    ts: v.optional(v.number()),
+  },
+  handler: async (ctx, { palaceId, neopId, kind, event, runId, ts }) => {
+    await ctx.db.insert("run_events", {
+      palaceId,
+      neopId,
+      runId,
+      kind,
+      event,
+      ts: ts ?? Date.now(),
+    });
+    // Interim bound: keep only the most-recent RUN_EVENT_CAP for this seat.
+    const rows = await ctx.db
+      .query("run_events")
+      .withIndex("by_palace_neop_ts", (q) => q.eq("palaceId", palaceId).eq("neopId", neopId))
+      .order("desc")
+      .collect();
+    let trimmed = 0;
+    for (const row of rows.slice(RUN_EVENT_CAP)) {
+      await ctx.db.delete(row._id);
+      trimmed++;
+    }
+    return { status: "ok", upsert: "insert", trimmed };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -366,6 +366,23 @@ export default defineSchema({
     .index("by_palace_run", ["palaceId", "runId"]) // load/resolve key here → neopId read FROM the row
     .index("by_palace_status", ["palaceId", "status"]),
 
+  // ── RUN EVENTS (INTERIM shadow-prediction store for the fidelity clock; Track 3) ──
+  // One row per emitted run event (currently only `shadow_prediction`), ADDRESSED by (palaceId, neopId).
+  // The runtime owns the `event` shape (predicted/actual/class); the server is a BLIND store, like twins /
+  // paused_runs. INTERIM BY DESIGN: this lets the fidelity clock warm BEFORE the comms tier lands — the
+  // durable event corpus MOVES to ClickHouse when enable_comms_tier applies (Track 2). Bounded on write
+  // (per-seat cap in runEvents.putRunEvent) so Convex never becomes the event firehose. See palace/runEvents.ts.
+  run_events: defineTable({
+    palaceId: v.id("palaces"),
+    neopId: v.string(),                    // = seat that owns the event (server-derived, never the caller's)
+    runId: v.optional(v.string()),         // correlation to the run (optional)
+    kind: v.string(),                      // "shadow_prediction" (the fidelity signal)
+    event: v.any(),                        // runtime-owned shape {predicted, actual, class, ...}
+    ts: v.number(),                        // event time (runtime-supplied, else server now)
+  })
+    .index("by_palace_neop", ["palaceId", "neopId"])
+    .index("by_palace_neop_ts", ["palaceId", "neopId", "ts"]),
+
   // ── VECTOR EMBEDDINGS (versioned by model) ───────────────────
 
   closet_embeddings: defineTable({

--- a/tests/runEvents.test.ts
+++ b/tests/runEvents.test.ts
@@ -1,0 +1,101 @@
+// run_events — the INTERIM shadow-prediction store for the fidelity clock (Track 3).
+//
+// Covers the handler contract (blind store, newest-first, bounded read, kind filter) and OWN-SEAT
+// isolation (a seat reads only its own events), plus the ACL op-map (get→recall / put→remember) so the
+// /mcp gate treats these like every other own-seat tool. The full /mcp permission enforcement is covered
+// by access.test.ts; here we assert the tool→op wiring and the query/mutation round-trip directly.
+//
+// Run: `npm test`
+
+import { describe, expect, test } from "vitest";
+import { convexTest } from "convex-test";
+import { api } from "../convex/_generated/api.js";
+import schema from "../convex/schema.js";
+import { runtimeOpForTool } from "../convex/access/enforce.js";
+
+async function makePalace(t: ReturnType<typeof convexTest>) {
+  return await t.mutation(api.palace.mutations.createPalace, {
+    name: "Test Palace",
+    clientId: "test",
+    falkordbGraph: "test_graph",
+    createdBy: "system",
+  });
+}
+
+const shadow = (predicted: string, actual: string) => ({
+  kind: "shadow_prediction",
+  predicted,
+  actual,
+  class: "selective",
+});
+
+describe("run_events — interim fidelity store", () => {
+  test("put then get round-trips the runtime-owned event, newest-first", async () => {
+    const t = convexTest(schema);
+    const palaceId = await makePalace(t);
+
+    await t.mutation(api.palace.runEvents.putRunEvent, {
+      palaceId, neopId: "aria", kind: "shadow_prediction", event: shadow("older", "a"), ts: 100,
+    });
+    await t.mutation(api.palace.runEvents.putRunEvent, {
+      palaceId, neopId: "aria", kind: "shadow_prediction", event: shadow("newer", "b"), ts: 200,
+    });
+
+    const { events, count } = await t.query(api.palace.runEvents.getRunEvents, {
+      palaceId, neopId: "aria",
+    });
+    expect(count).toBe(2);
+    expect(events[0].predicted).toBe("newer"); // desc by ts
+    expect(events[1].predicted).toBe("older");
+  });
+
+  test("OWN-SEAT isolation: a seat reads only its own events", async () => {
+    const t = convexTest(schema);
+    const palaceId = await makePalace(t);
+    await t.mutation(api.palace.runEvents.putRunEvent, {
+      palaceId, neopId: "aria", kind: "shadow_prediction", event: shadow("aria-1", "x"), ts: 1,
+    });
+    await t.mutation(api.palace.runEvents.putRunEvent, {
+      palaceId, neopId: "recon", kind: "shadow_prediction", event: shadow("recon-1", "y"), ts: 1,
+    });
+
+    const aria = await t.query(api.palace.runEvents.getRunEvents, { palaceId, neopId: "aria" });
+    expect(aria.count).toBe(1);
+    expect(aria.events[0].predicted).toBe("aria-1"); // never sees recon's row
+  });
+
+  test("kind filter + read limit are honored", async () => {
+    const t = convexTest(schema);
+    const palaceId = await makePalace(t);
+    await t.mutation(api.palace.runEvents.putRunEvent, {
+      palaceId, neopId: "aria", kind: "shadow_prediction", event: shadow("s", "x"), ts: 2,
+    });
+    await t.mutation(api.palace.runEvents.putRunEvent, {
+      palaceId, neopId: "aria", kind: "twin_written", event: { kind: "twin_written" }, ts: 3,
+    });
+
+    const onlyShadow = await t.query(api.palace.runEvents.getRunEvents, {
+      palaceId, neopId: "aria", kind: "shadow_prediction",
+    });
+    expect(onlyShadow.count).toBe(1);
+    expect(onlyShadow.events[0].kind).toBe("shadow_prediction");
+
+    const limited = await t.query(api.palace.runEvents.getRunEvents, {
+      palaceId, neopId: "aria", limit: 1,
+    });
+    expect(limited.count).toBe(1); // newest only
+    expect(limited.events[0].kind).toBe("twin_written"); // ts=3 is newest
+  });
+
+  test("empty seat → { events: [], count: 0 } (no throw)", async () => {
+    const t = convexTest(schema);
+    const palaceId = await makePalace(t);
+    const res = await t.query(api.palace.runEvents.getRunEvents, { palaceId, neopId: "nobody" });
+    expect(res).toEqual({ events: [], count: 0 });
+  });
+
+  test("ACL op-map: get→recall, put→remember (gated like every own-seat tool)", () => {
+    expect(runtimeOpForTool("palace_get_run_events")).toBe("recall");
+    expect(runtimeOpForTool("palace_put_run_event")).toBe("remember");
+  });
+});


### PR DESCRIPTION
Adds a bounded, explicitly **interim** run-event store so the shadow-fidelity clock can warm **before** the comms tier (ClickHouse) lands — the NEURAL-ops runner's `load_events` (`palace_get_run_events`) now has a real backing tool instead of a phantom seam.

**Interim by design.** The palace normally stores the folded twin, not the event firehose — that's ClickHouse's job. This table is a stopgap: the durable event corpus **moves to ClickHouse when `enable_comms_tier` applies (Track 2)**. It's bounded so Convex never becomes the firehose (`RUN_EVENT_CAP=1000` per seat, trimmed on write; bounded reads).

- `schema.ts`: `run_events` table, ADDRESSED by `(palaceId, neopId)` like twins/paused_runs; server is a blind store (runtime owns the `event` shape).
- `palace/runEvents.ts`: `getRunEvents` (newest-first, bounded, `kind` filter) + `putRunEvent` (blind append + per-seat trim).
- `http.ts`: `palace_get_run_events` / `palace_put_run_event` dispatch cases — same own-seat discipline as twins/paused_runs (neopId server-overwritten; a caller reaches only its OWN events).
- `enforce.ts` `TOOL_TO_OP`: get→`recall`, put→`remember` (gated like every own-seat tool).
- `_generated/api.d.ts`: register the `runEvents` module (codegen parity — offline codegen needs a deployment, so hand-added exactly as codegen emits).

Tests (`tests/runEvents.test.ts`): round-trip newest-first, **own-seat isolation**, kind filter + limit, empty seat, and the ACL op-map. **Full suite 100 passed / 1 skipped; `tsc --noEmit` clean.**

Additive schema change (new table only) — safe to merge; the `convex deploy` that applies it is separately gated (CONVEX_DEPLOY_KEY).